### PR TITLE
feature: implement new download option for large px files:

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,9 +15,13 @@ RoxygenNote: 7.2.3
 Imports: 
     assertthat,
     BFS,
+ Imports: 
+    assertthat,
+    BFS,
     dplyr,
     googlesheets4,
     magrittr,
-    pxRRead,
     tibble,
     tidyr
+Remotes:  
+    SDSC-ORD/pxRRead

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,5 +18,6 @@ Imports:
     dplyr,
     googlesheets4,
     magrittr,
+    pxRRead,
     tibble,
     tidyr

--- a/R/download_data.R
+++ b/R/download_data.R
@@ -92,10 +92,15 @@ read_data.default <- function(ds) {
 #' d <- pxweb::pxweb_interactive("https://www.pxweb.bfs.admin.ch/api/v1/de/px-x-0103010000_102")
 #'
 read_data.px <- function(ds){
-
-  ds$data <- BFS::bfs_get_data(number_bfs = ds$read_path, language = ds$lang)
-
-
+  if (ds$size != "large") {
+    ds$data <- BFS::bfs_get_data(number_bfs = ds$read_path,
+                                 language = ds$lang)
+  } else {
+    df <- pxRRead::scan_px_file(ds$read_path,
+                                locale = ds$lang,
+                                encoding = ds$encoding)
+    ds$data <- df$dataframe
+  }
   return(ds)
 }
 

--- a/R/get_read_path.R
+++ b/R/get_read_path.R
@@ -59,12 +59,16 @@ get_read_path_bfs.default <- function(ds){
 #'
 #' the asset number (BFS Nr) is required
 get_read_path_bfs.px <- function(ds){
-
-
-  # Create the download url
-  # all required information, like the name of the data cube, are in the dataset (ds)
-  # Example: name of the data cube ("px-x-0103010000_102") is taken from ds$data_id
-  ds$read_path <- ds$sheet
+  print(ds$size)
+  if (ds$size != "large") {
+    # Create the download url
+    # all required information, like the name of the data cube, are in the dataset (ds)
+    # Example: name of the data cube ("px-x-0103010000_102") is taken from ds$data_id
+    ds$read_path <- ds$sheet
+  } else {
+    ds$read_path <- paste0("https://www.pxweb.bfs.admin.ch/DownloadFile.aspx?file=",
+                           ds$sheet)
+  }
 
   return(ds)
 }


### PR DESCRIPTION
when `ds$size` is set to `large` the package `pxRRead` will be used to parse a dataset of `ds$format`: `px`
`pxRRead` works for diffferent file encodings: the default is `latin1` Some px cubes are encoded in `UTF-8`. Set `ds$encoding` accordingly.