### PR TITLE
feat(A1): convert to wide format

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,22 +1,23 @@
 Package: statbotData
 Title: What the Package Does (One Line, Title Case)
 Version: 0.0.0.9000
-Authors@R: 
+Authors@R:
     person("First", "Last", , "first.last@example.com", role = c("aut", "cre"),
            comment = c(ORCID = "YOUR-ORCID-ID"))
 Description: What the package does (one paragraph).
 License: MIT + file LICENSE
-Suggests: 
+Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
-Imports: 
+Imports:
     assertthat,
     BFS,
     dplyr,
     googlesheets4,
     magrittr,
+    stringdist,
     tibble,
     tidyr

--- a/scripts/A1.R
+++ b/scripts/A1.R
@@ -25,7 +25,7 @@ ds$data %>%
       TRUE ~ grossregion_kanton
     )
   ) %>%
-  dplyr::filter(!stringr::str_detect(grossregion_kanton, '<<')) %>%
+  dplyr::filter(!stringr::str_detect(grossregion_kanton, "<<")) %>%
   dplyr::mutate(grossregion_kanton = stringr::str_replace(grossregion_kanton, "^-", "")) %>%
   dplyr::mutate(grossregion_kanton = stringr::str_trim(grossregion_kanton)) -> ds$data
 
@@ -59,7 +59,7 @@ name_mapping <- data.frame(
 # Replace the names in grossregion_kanton using the mapping
 ds$data <- ds$data %>%
   dplyr::left_join(name_mapping, by = "grossregion_kanton") %>%
-  dplyr::mutate(grossregion_kanton = ifelse(spatialunit_ontology == 'Canton' & !is.na(name_de), name_de, grossregion_kanton)) %>%
+  dplyr::mutate(grossregion_kanton = ifelse(spatialunit_ontology == "Canton" & !is.na(name_de), name_de, grossregion_kanton)) %>%
   dplyr::select(-name_de)
 
 
@@ -84,11 +84,18 @@ ds$data %>%
   dplyr::rename(
     "genutzte_infrastruktur" = infrastruktur,
     "geraet_oder_untersuchung" = gerate_und_untersuchungen,
-     "anzahl" = medizinisch_technische_infrastruktur_anzahl_gerate_und_untersuchungen_in_krankenhausern
+    "anzahl" = medizinisch_technische_infrastruktur_anzahl_gerate_und_untersuchungen_in_krankenhausern
   ) -> ds$data
 
 
+# widen table -------------------------------------------------------------
+
+ds$data %>%
+  tidyr::pivot_wider(
+    names_from = c("geraet_oder_untersuchung"),
+    values_from = anzahl
+  ) %>%
+  janitor::clean_names() -> ds$data
+
 
 # ingest into postgres ----------------------------------------------------
-
-

--- a/scripts/A1.R
+++ b/scripts/A1.R
@@ -93,9 +93,11 @@ ds$data %>%
 ds$data %>%
   tidyr::pivot_wider(
     names_from = c("geraet_oder_untersuchung"),
-    values_from = anzahl
+    values_from = anzahl,
+    names_prefix = "anzahl_"
   ) %>%
-  janitor::clean_names() -> ds$data
-
+  janitor::clean_names() %>%
+  dplyr::rename("anzahl_gerate" = anzahl_anzahl_gerate) %>%
+  dplyr::select(-spatialunit_ontology) -> ds$data
 
 # ingest into postgres ----------------------------------------------------


### PR DESCRIPTION
This PR converts A1 from tidy to wide format. Namely, it creates a new column for each level of the `geraet_oder_untersuchung` and inserts corresponding values from the `anzahl` column. Here is a glimpse at the table structure:

Before:

```
Rows: 7,776
Columns: 6
$ genutzte_infrastruktur   <chr> "Angiographiegeräte", "Angiographiegeräte", "…
$ geraet_oder_untersuchung <chr> "Anzahl Geräte", "Anzahl Geräte", "Anzahl Ger…
$ jahr                     <chr> "2013", "2014", "2015", "2016", "2017", "2018…
$ anzahl                   <dbl> 137, 138, 146, 143, 136, 136, 128, 141, 145, …
$ spatialunit_ontology     <chr> "Country", "Country", "Country", "Country", "…
$ spatialunit_uid          <chr> "0_CH", "0_CH", "0_CH", "0_CH", "0_CH", "0_CH…
```
After:

```
Rows: 1,944
Columns: 8
$ genutzte_infrastruktur    <chr> "Angiographiegeräte", "Angiographiegeräte", …
$ jahr                      <chr> "2013", "2014", "2015", "2016", "2017", "201…
$ spatialunit_ontology      <chr> "Country", "Country", "Country", "Country", …
$ spatialunit_uid           <chr> "0_CH", "0_CH", "0_CH", "0_CH", "0_CH", "0_C…
$ anzahl_gerate             <dbl> 137, 138, 146, 143, 136, 136, 128, 141, 145,…
$ untersuchungen_total      <dbl> 105713, 116967, 119395, 121854, 118025, 1209…
$ ambulante_untersuchungen  <dbl> 50540, 52212, 55384, 48955, 52134, 53721, 58…
$ stationare_untersuchungen <dbl> 54383, 62891, 62205, 68094, 65035, 66594, 62…
```

And a screenshot of what the table would look like after this PR:

![image](https://github.com/statistikZH/statbotData/assets/22558602/ca374c3d-aa3c-4cfd-8f85-da460f4a8915)

