### PR TITLE
repair installation:  `DESCRIPTION`: remove double `Imports`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -15,9 +15,6 @@ RoxygenNote: 7.2.3
 Imports: 
     assertthat,
     BFS,
- Imports: 
-    assertthat,
-    BFS,
     dplyr,
     googlesheets4,
     magrittr,


### PR DESCRIPTION
this bug was entered by a previous commit