### PR TITLE
feat(A14): add pipeline

### DIFF
--- a/scripts/A14.R
+++ b/scripts/A14.R
@@ -1,0 +1,80 @@
+# create ds object --------------------------------------------------------
+
+ds <- create_dataset(id = "A14")
+
+
+# download the data -------------------------------------------------------
+
+ds <- download_data(ds)
+
+# read in the spatial data ------------------------------------------------
+
+spatial_unit_df <- readr::read_csv("data/const/spatial_unit_postgres.csv")
+
+# data cleaning -----------------------------------------------------------
+
+### add spatial unit column "Switzerland"
+global_products <- c(
+  "Share of tourism of the regional total (in %)",
+  "Total of tourism of the economy"
+)
+
+indicators <- c(
+  "Tourism-connected gross value added (at current prices, in million CHF)",
+  "Tourism-related employment (FTE)"
+)
+
+# Filter relevant factors and cleanup
+ds$data <- ds$data %>%
+  janitor::clean_names() %>%
+  tibble::as_tibble() %>%
+  dplyr::filter(product %in% global_products) %>%
+  dplyr::filter(indicator %in% indicators) %>%
+  dplyr::rename(
+    "value" = regional_indicators_of_the_tourism_satellite_accounts
+  )
+
+# Pivot to separate employment from CHF values
+ds$data <- ds$data %>%
+  tidyr::pivot_wider(names_from = indicator, values_from = value) %>%
+  dplyr::rename(
+    gross_value_added = "Tourism-connected gross value added (at current prices, in million CHF)",
+    employment = "Tourism-related employment (FTE)"
+  )
+
+# Pivot again to separate total from percentage
+ds$data <- ds$data %>%
+  tidyr::pivot_wider(
+    values_from = c(gross_value_added, employment),
+    names_from = product,
+  ) %>%
+  janitor::clean_names()
+
+# Ensure clear column names
+ds$data <- ds$data %>%
+  dplyr::rename(
+    "mio_chf_gross_value_added_of_tourism" = gross_value_added_total_of_tourism_of_the_economy,
+    "total_full_time_employment_of_tourism" = employment_total_of_tourism_of_the_economy,
+    "percent_share_gross_value_added_of tourism" = gross_value_added_share_of_tourism_of_the_regional_total_in_percent,
+    "percent_share_full_time_employment_of_tourism" = employment_share_of_tourism_of_the_regional_total_in_percent
+  )
+
+# join the cleaned data to the postgres spatial units table ---------------
+
+spatial_map <- ds$data %>%
+  dplyr::select(canton) %>%
+  dplyr::distinct(canton) %>%
+  map_ds_spatial_units()
+
+ds$data %>%
+  dplyr::left_join(spatial_map, by = "canton") %>%
+  dplyr::select(-canton) -> ds$data
+
+## check that each spatial unit could be matched -> this has to be TRUE
+
+assertthat::noNA(ds$data$spatialunit_uid)
+
+
+# ingest into postgres ----------------------------------------------------
+
+### important: name the table as energiebilanz_schweiz_in_tera_joule

--- a/scripts/A14.R
+++ b/scripts/A14.R
@@ -55,7 +55,7 @@ ds$data <- ds$data %>%
   dplyr::rename(
     "mio_chf_gross_value_added_of_tourism" = gross_value_added_total_of_tourism_of_the_economy,
     "total_full_time_employment_of_tourism" = employment_total_of_tourism_of_the_economy,
-    "percent_share_gross_value_added_of tourism" = gross_value_added_share_of_tourism_of_the_regional_total_in_percent,
+    "percent_share_gross_value_added_of_tourism" = gross_value_added_share_of_tourism_of_the_regional_total_in_percent,
     "percent_share_full_time_employment_of_tourism" = employment_share_of_tourism_of_the_regional_total_in_percent
   )
 

--- a/scripts/A14.R
+++ b/scripts/A14.R
@@ -9,6 +9,9 @@ ds <- download_data(ds)
 
 # data cleaning -----------------------------------------------------------
 
+### Filter specific products and indicators
+# NOTE: We only look at tourism as a whole, and not sectors of tourism.
+
 global_products <- c(
   "Share of tourism of the regional total (in %)",
   "Total of tourism of the economy"

--- a/scripts/A14.R
+++ b/scripts/A14.R
@@ -7,13 +7,8 @@ ds <- create_dataset(id = "A14")
 
 ds <- download_data(ds)
 
-# read in the spatial data ------------------------------------------------
-
-spatial_unit_df <- readr::read_csv("data/const/spatial_unit_postgres.csv")
-
 # data cleaning -----------------------------------------------------------
 
-### add spatial unit column "Switzerland"
 global_products <- c(
   "Share of tourism of the regional total (in %)",
   "Total of tourism of the economy"


### PR DESCRIPTION
Adds the pipeline for dataset A14 (https://github.com/statistikZH/statbotData/issues/35): Regional indicators of the Tourism Satellite Accounts by canton and product and Year

Due to the complexity of the dataset, a subset of products and indicators have been selected. A14 is only meant to show the importance of tourism in the local economy of each canton in terms of "gross added value" and "employment".

More detailed products such as the sectors of tourism (sport, travel agencies, restaurants, ...) were excluded. If we consider them important, they could be made into a separate table.
```
Rows: 108
Columns: 6
$ year                                          <chr> "2016", "2017", "2018", …
$ mio_chf_gross_value_added_of_tourism          <dbl> 18378.21, 19167.55, 1994…
$ `percent_share_gross_value_added_of tourism`  <dbl> 2.79, 2.89, 2.89, 2.53, …
$ total_full_time_employment_of_tourism         <dbl> 166446.25, 169334.33, 17…
$ percent_share_full_time_employment_of_tourism <dbl> 4.19, 4.22, 4.26, 3.77, …
$ spatialunit_uid                               <chr> "0_CH", "0_CH", "0_CH", …
```

![image](https://github.com/statistikZH/statbotData/assets/22558602/d657e095-0304-401f-ac79-0663b16c29ad)
