### PR TITLE
Work on issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/dataset-proposal.md
+++ b/.github/ISSUE_TEMPLATE/dataset-proposal.md
@@ -12,11 +12,12 @@ assignees: ''
 ## Dataset properties
 
 * URL: [Source URL of the dataset]
+* Organization: which organization does the dataset belong to (example: Canton Aargau)
 * format: [Source format of the data: xlsx,px,json,rdf,csv,...]
 * size: [XXMB]
 * dimensions: [Variables to include in the dataset]
 * units: [Units used for values]
-* lang: [Language(s) used in the dataset: en,de,fr,it]
+* lang: [language that the pipeline will be build in]
 
 ## Additional notes
 

--- a/.github/ISSUE_TEMPLATE/general-question.md
+++ b/.github/ISSUE_TEMPLATE/general-question.md
@@ -1,0 +1,12 @@
+---
+name: General Question
+about: Serves to raise issues on the general approach
+title: 'General Question'
+labels: general_approach
+assignees: ''
+
+---
+
+## Topic
+
+## Question or Proposal


### PR DESCRIPTION
This PR:

- adds an issue template for general questions
- changes the issue template for datasets to also include the releasing organisation: also `lang` should just set the one language the pipeline will be build in 