### PR TITLE
add script to write a csv file with datasets and query counts

### DIFF
--- a/R/dataset-list.R
+++ b/R/dataset-list.R
@@ -1,0 +1,36 @@
+# load all the possible data sets
+pattern_pipeline_indicator <- '[:upper:][:digit:]+'
+pipeline_metadata <- googlesheets4::read_sheet(
+  ss = "https://docs.google.com/spreadsheets/d/11V8Qj4v21MleMk_W9ZnP_mc4kmp0CNvsmd9w4A9sTyo/edit?usp=sharing",
+  sheet = "tables")
+
+# get all pipeline ids
+pipelines <- list.files("pipelines/")
+
+# get the query counts for the pipelines
+query_counts <- c()
+for (pipeline_indicator in pipelines) {
+  query_log_path <- paste0("pipelines/", pipeline_indicator, "/queries.log")
+  if (file.exists(query_log_path)) {
+    queries <- readr::read_file(query_log_path)
+    query_count <- stringr::str_count(queries, "--")
+    print(paste(pipeline_indicator, query_count))
+    query_counts <- c(query_counts, query_count)
+  }
+}
+
+# make a tibble with query counts and pipeline indicators
+counts <- tibble::tibble(pipelines, query_counts) %>%
+  dplyr::rename(pipeline=pipelines)
+counts
+
+# join the two tables
+choices <- pipeline_metadata %>%
+  dplyr::filter(data_indicator %in% pipelines) %>%
+  dplyr::select(c(publisher, lang, data_indicator, name)) %>%
+  dplyr::rename(pipeline=data_indicator) %>%
+  dplyr::left_join(counts, by = "pipeline")
+choices
+
+# write a csv file
+write.csv(choices, row.names=FALSE, quote=FALSE, file="dataset_and_query_count.csv")

--- a/dataset_and_query_count.csv
+++ b/dataset_and_query_count.csv
@@ -1,0 +1,17 @@
+publisher,lang,pipeline,name,query_counts
+fso,de,A1,medizinisch_technische_infrastruktur,1
+fso,en,A3,treibhausgasemission_in_mio_tonnen,1
+fso,de,A4,energiebilanz_schweiz_in_tera_joule,1
+fso,de,A5,ahv_renten_nach_wohnsitz_und_staatsangehoerigkeit,1
+fso,de,A6,abstimmungsvorlagen_seit_1971,20
+fso,de,A7,arztpraxen_ambulante_zentren,1
+fso,de,A8,nationalratswahlen,4
+fso,de,A10,straftaten_aufklaerung,5
+fso,de,S1,median_strompreis_per_kanton,1
+fso,de,A13,pflanzungen_schweiz,1
+fso,de,S3,staatsausgaben_nach_aufgabenbereichen_cofog,10
+fso,en,A14,tourism_economy_by_canton,8
+fso,en,A15,employees_farmholdings_agricultural_area_livestock_per_canton,7
+fso,en,A16,demographic_balance_by_canton,10
+fso,de,A17,volksabstimmung_nach_kanton_seit_1861,1
+basel_land,de,A21,basel_land_endverbrauch_von_ektrizitat_nach_gemeinde_und_jahr_seit_1990,8


### PR DESCRIPTION
This PR aims to do the following steps:
- implement a csv file for the pipeline processing instead of the previously used google sheet
- generate a report of the status of the pipelines in regards to number of queries and language of the dataset