### PR TITLE
docs(README.md): fix spelling in class diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ The statbot input data `statbot_input_data.csv` describes datasets that are avai
 classDiagram
     Dataset <|-- PxCube
     Dataset <|-- CsvFile
-    Dataset <|-- ExelSheet
+    Dataset <|-- ExcelSheet
     Dataset <|-- LINDAS
     Dataset : data_indicator
     Dataset : status


### PR DESCRIPTION
This PR fixes an error in class diagram on the README: a class was spelt in two different ways.