### PR TITLE
Move queries from b6 to b1

### DIFF
--- a/pipelines/B1/queries.log
+++ b/pipelines/B1/queries.log
@@ -1,4 +1,4 @@
-[1] "Environment: REMOTE, Time: 2023-10-27 16:32:11"
+[1] "Environment: REMOTE, Time: 2023-11-23 18:45:23.29397"
 
 Query Nr. 1
 -- What was the proportion of electric vehicles in Geneva in 2010?
@@ -25,8 +25,8 @@ SELECT DISTINCT fuel_type FROM stock_vehicles;
  Benzine-electric: Plug-in-hybrid
          Gas (mono- and bivalent)
                            Diesel
-  Diesel-electric: Plug-in-hybrid
                           Benzine
+  Diesel-electric: Plug-in-hybrid
                          Electric
    Diesel-electric: Normal-hybrid
                          Hydrogen
@@ -1222,492 +1222,7 @@ SELECT su.name AS city FROM spatial_unit su WHERE NOT EXISTS (     SELECT 1     
                                    Stampa
                                  Wil (AG)
                       Reckingen-Gluringen
-                               Eschikofen
-                         Region Unterland
-                                   Dongio
-                                    Luven
-                              Escher Wyss
-                       District de Morges
-                            St. Peterzell
-                           Salen-Reutenen
-                        District de Rolle
-                                  Riedern
-                                  Mitlödi
-                           Bezirk Plessur
-                                    Flond
-                          Bergün/Bravuogn
-                                   Moleno
-                               Roggenburg
-                                 Dotnacht
-                                  Ghirone
-                                  Wahlern
-                           Herznach-Ueken
-                                     Rona
-                           Bezirk Imboden
-                                 Intragna
-                             Uerschhausen
-                             Zihlschlacht
-                               Pregassona
-                       Mannens-Grandsivaz
-                             Marbach (LU)
-                                     Envy
-                                 Boncourt
-                     District d'Echallens
-                                       Lü
-                                  Montana
-                        Bezirk Werdenberg
-                     Schwamendingen-Mitte
-                                 Ecoteaux
-                                 Ettingen
-                               Ligornetto
-                                Courlevon
-                                  Cordast
-                           Kyburg-Buchegg
-                            Biogno-Beride
-                                Gluringen
-                                 Thundorf
-                             Granges (VS)
-                                   Mettau
-                              Grattavache
-                                 Correvon
-                               Aesch (BL)
-                     Distretto di Bernina
-                                     Ftan
-                                   Umiken
-                                 Montenol
-                Saint-Saphorin-sur-Morges
-                            Willisau Land
-                                Soyhières
-                                 Pampigny
-                      Altstadt Kleinbasel
-                          Burg bei Murten
-                                Salvenach
-                           Le Peuchapatte
-                              Montbrelloz
-                            Region Zürich
-                                Mervelier
-                                Thierrens
-                            Büren zum Hof
-                           Mühledorf (SO)
-                Dippishausen-Oftershausen
-                                   Lovens
-                                 Vellerat
-                         Prez-vers-Noréaz
-                   Bezirk Untertoggenburg
-                          Balm bei Messen
-                                Aegerisee
-                                Vorstädte
-                            Montfavergier
-                                   Suraua
-                              Küttigkofen
-                                  Bidogno
-                                Wipkingen
-                                 Gordevio
-                               St. Johann
-                                  Posieux
-                                  Frasses
-                              Bollodingen
-           Bielersee / Lac de Bienne (NE)
-                               Harenwilen
-                        Farvagny-le-Petit
-                                Sarnersee
-                                 Wildhaus
-                              Dettighofen
-                              Courchapoix
-                                 Brügglen
-                                    Malix
-                                 Cugnasco
-                               Oberstrass
-                                Cresciano
-                                  Mosogno
-         Lac de la Gruyère / Greyerzersee
-                        Busswil bei Büren
-                                   Glarus
-                            Grandfontaine
-                                   Sassel
-                           Les Thioleyres
-                                  Kreis 1
-                                Gutenburg
-                                 Bionnens
-                          Amtsbezirk Bern
-                       District d'Aubonne
-                         Chapelle (Broye)
-                                     Pizy
-                              La Neirigue
-                                 Calonico
-                               Macconnens
-                               Herblingen
-                                     Gudo
-                                  Wanzwil
-                              Waltalingen
-                               Schlosswil
-                                   Coeuve
-                               Carabietta
-                              Leuggelbach
-                                 Filzbach
-                                   Apples
-                                   Isorno
-                                     Sarn
-                                    Mosen
-                District de la Neuveville
-                              Fregiécourt
-                              Cournillens
-                              Hautemorges
-                                   Horben
-                                  Morlens
-                          Region Weinland
-                                 Sigirino
-                               Friltschen
-                        Villette (Lavaux)
-                           Peyres-Possens
-                                Giubiasco
-                                   Versam
-                               Hirzenbach
-        Bezirksfreies Gebiet Bern / Berne
-                                Altavilla
-                            Thielle-Wavre
-                              Hugelshofen
-                                 Moghegno
-                               La Rougève
-                                 Le Glèbe
-                           Schinznach-Bad
-                              Estavannens
-                             Les Tavernes
-                                   Mossel
-                          Staatswald Galm
-                                 Vuissens
-                                   Coglio
-                       District de Boudry
-                                 Largario
-                            Walensee (GL)
-                                Campestro
-                                  Bratsch
-                                Pleujouse
-                                  Croglio
-                                Hätzingen
-                                  Preonzo
-                               Grellingen
-            Murtensee / Lac de Morat (FR)
-                               Greifensee
-                               Engishofen
-                              Brienzersee
-                                   Iragna
-                              Gänsbrunnen
-                                  Cheyres
-                                   Clugin
-                              Dünnershaus
-                                   Märwil
-                               Chandossel
-                              Ettenhausen
-                                    Bivio
-                            Wilen bei Wil
-                                     Lüen
-                   Amtsbezirk Fraubrunnen
-                                Le Saulgy
-                                 Courroux
-                                   Delley
-                           Marin-Epagnier
-                                 Anzonico
-                                Fescoggia
-                           Pambio-Noranco
-                                  Pleigne
-                                   Breite
-                                Malapalud
-                                 Kreis 10
-                                 Cimadera
-                                   Riehen
-                                  Parsonz
-                             Reinach (BL)
-                                Courtaman
-                                   Cunter
-                               Amt Sursee
-                            Mézières (VD)
-                                Bütschwil
-                               Nenzlingen
-                            Prato-Sornico
-                             Môtiers (NE)
-                                  Nidfurn
-                                Vauderens
-                     Chézard-Saint-Martin
-                                Cormagens
-                                Montmelon
-                             Bronschhofen
-                              Les Friques
-                      Medels im Rheinwald
-                                     Says
-                                  Goumois
-                             Les Breuleux
-                                   Littau
-                                  Portein
-                  Amtsbezirk Trachselwald
-                                 Oerlikon
-                                    Tobel
-                       Bezirk Hinterrhein
-                              Sternenberg
-                                Müswangen
-                                 Röschenz
-                          Amtsbezirk Biel
-                      Bezirk Oberrheintal
-             Bezirksfreies Gebiet Thurgau
-                                   Tomils
-                                Gentilino
-                                Sulz (AG)
-                               Liebistorf
-                        Amtsbezirk Laupen
-                                 Delémont
-                      Bezirk Bischofszell
-                                 Ulrichen
-                                 Brislach
-                                    Seiry
-                                   Iselin
-                       Les Hauts-Geneveys
-                              Courchapoix
-                               Castagnola
-                             Schwendibach
-                             Münchenstein
-                               Charmoille
-                              Rossemaison
-                                Ritzingen
-                               Haut-Vully
-                                    Crana
-                                  Esmonts
-                         Amtsbezirk Büren
-                                  Damvant
-                    La Chaux-des-Breuleux
-                                 Vollèges
-                                 Mur (VD)
-                              Undervelier
-                                 Eschiens
-                                  Travers
-                                Epiquerez
-                               Tägertschi
-                        Schönenbaumgarten
-                                Chésalles
-                              Niederurnen
-                                 Morissen
-                                Pfeffikon
-                                 Vuippens
-                                  Epesses
-                                Geschinen
-                              Benken (BL)
-                               Stein (SG)
-                                  Tschlin
-                                   Safien
-                                  Schnaus
-                           Kirchenthurnen
-                                 Grimentz
-                         Forel-sur-Lucens
-                               Lipperswil
-                             Rheinklingen
-                      Chapelle-sur-Moudon
-                                   Lugnez
-                                   Soulce
-                                Gossliwil
-                                     Igis
-                              Langstrasse
-                             Unterschlatt
-                                Burgäschi
-                       Bezirk Val Müstair
-                               Courchavon
-                         Nierlet-les-Bois
-                                  Gunzwil
-                              Scherzingen
-                                Glovelier
-                              Kalthäusern
-                   Amtsbezirk Konolfingen
-                                Eclagnens
-                               Sommentier
-                               Niederösch
-                               Villarepos
-                                 Auressio
-                                   Muggio
-                                   Rivera
-                                 Liesberg
-                          Ponto Valentino
-                             Bressaucourt
-                                  Réclère
-                        District de Vevey
-                                La Corbaz
-                                   Tartar
-                         District d'Aigle
-                                 Savognin
-                              Alterswilen
-                            Tumegl/Tomils
-                           Bezirk Glenner
-                                 Albligen
-                             Saignelégier
-                                Monteggio
-                                    Sagno
-                                Sulz (LU)
-                                Savagnier
-                          Oberehrendingen
-                                   Le Bry
-                               Bettwiesen
-                             Gelterfingen
-                                 Pianezzo
-                               Cavigliano
-                                 Val Mara
-                    District de Neuchâtel
-                               Wallenried
-                  Corcelles-sur-Chavornay
-                               Englisberg
-                               Bezirk See
-                                Mühlehorn
-                               Gommiswald
-                                  Zurzach
-                                 Dussnang
-                         St. Gallenkappel
-                                   Bilten
-                                   Gnosca
-                                    Torre
-                                Wittenwil
-                                  Wattwil
-                               Salenstein
-                                   Stilli
-                           Weiningen (TG)
-                                   Salins
-                              Ernetschwil
-                                     Buix
-                                  Sihlsee
-                                St. Alban
-                          Eschenbach (SG)
-                                   Avegno
-                                     Linn
-                               Zimmerwald
-                                 Mairengo
-                           Alt St. Johann
-                                 Donatyre
-                               Altstetten
-                             Montsevelier
-                                 Farvagny
-                             Diessenhofen
-                      Amtsbezirk Seftigen
-                                Gelfingen
-                               Lussy (FR)
-                             Münster (VS)
-                  Vierwaldstättersee (UR)
-                                Hosenruck
-                          Happerswil-Buch
-                                    Höfen
-                      Amtsbezirk Burgdorf
-                           Willisau Stadt
-                                  Dättwil
-                        Amtsbezirk Signau
-                               Montfaucon
-                         Gerra (Verzasca)
-                             Unterbözberg
-                                  Hohtenn
-                                   Maules
-                      Combremont-le-Grand
-                        Amtsbezirk Wangen
-                                 Venthône
-                             Villargiroud
-                           Martigny-Ville
-                                Wettstein
-                               Saint-Jean
-                                  Gorduno
-                                  Brenles
-                      Region Pfannenstiel
-                              Hessenreuti
-                    Lac de Neuchâtel (FR)
-            Murtensee / Lac de Morat (VD)
-                                   Praden
-                                Duggingen
-                               Ichertswil
-                                    Erlen
-                          Staatswald Galm
-                                 Kulmerau
-                            Amt Entlebuch
-                                Fontenais
-                                  Uffikon
-                                 Villiers
-                              Guschelmuth
-                            Oron-la-Ville
-                             Guntmadingen
-                                   Tarasp
-                            Saint-Ursanne
-                                     Steg
-                               Les Glânes
-                   Corcelles-Cormondrèche
-                                 Vuibroye
-                                  Alvaneu
-                                   Sobrio
-                                Hermiswil
-                    Lac de Neuchâtel (BE)
-                                Vallamand
-                               Uesslingen
-                        Rueyres-Treyfayes
-                                  Vicques
-                                   Cornol
-                           Le Peuchapatte
-                               Aetigkofen
-                Les Geneveys-sur-Coffrane
-                       Region Knonaueramt
-                                     Engi
-                              Oberramsern
-                  Schönenberg an der Thur
-                                  Muriaux
-                                     Matt
-                                  Muttenz
-                     Distretto di Bernina
-                                  Vogorno
-                               Willisdorf
-                              Escholzmatt
-                                Steinhaus
-                                 Sihlfeld
-                                 Surcuolm
-                                   Haslen
-                                  Zénauva
-                            Walensee (SG)
-                                   Noflen
-                               Pfeffingen
-                                   Peseux
-                                Montbovon
-                        Oulens-sur-Lucens
-                                   Eyholz
-                                  Rossura
-                              Osterfingen
-                                 Aeschlen
-                Bleiken bei Oberdiessbach
-                                Rohr (SO)
-                               Oberflachs
-                               Alvaschein
-                       Innerer Landesteil
-                               Luchsingen
-                                    Breno
-                         Les Genevez (BE)
-                               Ederswiler
-                             Altdorf (SH)
-                                   Arosio
-                              Constantine
-                         Estavayer-le-Lac
-                                Léchelles
-                                Lohnstorf
-                              Hinterrhein
-                        Hallwilersee (AG)
-                        Amtsbezirk Wangen
-                                Birwinken
-                              San Nazzaro
-                           Villa Luganese
-                                Ittenthal
-                                 Corserey
-                    Mézery-près-Donneloye
-                             Oberbussnang
-                                  Paspels
-                              Münchringen
-                                    Fanas
-                               Bezirk Inn
-                                 Pontenet
-                                   Illens
-                           Torny-le-Grand
-                           Unterstammheim
-                               Estévenens
-                               Herlisberg
-                                  Nesslau
-                        Bussigny-sur-Oron
-                                 Oberwald
-                                  Limpach
-                              Vicosoprano
+ [ reached 'max' / getOption("max.print") -- omitted 486 rows ]
 
 Query Nr. 14
 -- What type of vehicle is the most frequent in the canton of Basel?
@@ -1760,3 +1275,255 @@ Query Nr. 19
 SELECT SUM(amount) AS total_diesel_industrial_vehicles FROM spatial_unit su INNER JOIN stock_vehicles sv ON su.spatialunit_uid = sv.spatialunit_uid WHERE su.name = 'Switzerland'     AND sv.vehicle_type = 'industrial vehicles'     AND sv.fuel_type = 'Diesel'     AND sv.year = 2013;
  total_diesel_industrial_vehicles
                            168254
+
+Query Nr. 20
+-- How many vehicles do we have in canton zurich in 2020?
+SELECT S.name, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%Zurich%'  and T.year=2020 and S.canton=True GROUP BY S.name;
+             name  amount
+ Canton of Zurich 2038628
+
+Query Nr. 21
+-- How many vehicles do we have in the city of zurich in 2021?
+SELECT S.name, S.spatialunit_ontology, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%Z_rich%'  and T.year=2021 and S.municipal=True and T.fuel_type != 'total' GROUP BY S.name, S.spatialunit_ontology;
+   name spatialunit_ontology amount
+ Zürich         Municipality 190773
+
+Query Nr. 22
+-- How many vehicles do we have in zurich in 2020?
+SELECT S.name, S.spatialunit_ontology, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%Z_rich%'  and T.year=2020 and (S.canton=True or S.municipal=True or S.district=True) GROUP BY S.name, S.spatialunit_ontology;
+             name spatialunit_ontology  amount
+    Bezirk Zürich             District  381178
+ Canton of Zurich               Canton 2038628
+           Zürich         Municipality  381178
+
+Query Nr. 23
+-- How many electric cars do we have in the city of basel?
+SELECT S.name, S.spatialunit_ontology,T.fuel_type,T.year, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%basel%'  and S.municipal=True and T.fuel_type ='Electric' GROUP BY S.spatialunit_ontology, S.name,T.fuel_type, T.year;
+  name spatialunit_ontology fuel_type year amount
+ Basel         Municipality  Electric 2010    100
+ Basel         Municipality  Electric 2011    106
+ Basel         Municipality  Electric 2012    122
+ Basel         Municipality  Electric 2013    138
+ Basel         Municipality  Electric 2014    168
+ Basel         Municipality  Electric 2015    200
+ Basel         Municipality  Electric 2016    245
+ Basel         Municipality  Electric 2017    295
+ Basel         Municipality  Electric 2018    372
+ Basel         Municipality  Electric 2019    538
+ Basel         Municipality  Electric 2020    767
+ Basel         Municipality  Electric 2021   1121
+
+Query Nr. 24
+-- How many hybrid cars do we have in the city of basel?
+SELECT S.name, S.spatialunit_ontology,T.fuel_type,T.year, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%basel%'  and S.municipal=True and T.fuel_type ilike '%hybrid%' GROUP BY S.spatialunit_ontology, S.name,T.fuel_type, T.year;
+  name spatialunit_ontology                        fuel_type year amount
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2010    279
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2011    333
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2012    393
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2013    504
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2014    567
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2015    604
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2016    716
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2017    791
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2018    864
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2019   1006
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2020   1245
+ Basel         Municipality  Benzine-electric: Normal-hybrid 2021   1755
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2010      0
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2011      0
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2012      1
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2013      3
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2014      4
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2015     18
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2016     36
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2017     65
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2018    103
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2019    183
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2020    430
+ Basel         Municipality Benzine-electric: Plug-in-hybrid 2021    518
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2010      1
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2011      3
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2012      7
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2013     15
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2014     20
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2015     27
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2016     28
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2017     33
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2018     44
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2019     95
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2020    193
+ Basel         Municipality   Diesel-electric: Normal-hybrid 2021    437
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2010      0
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2011      0
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2012      0
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2013      1
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2014      2
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2015      3
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2016      4
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2017      6
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2018      3
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2019      3
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2020      5
+ Basel         Municipality  Diesel-electric: Plug-in-hybrid 2021     11
+
+Query Nr. 25
+-- give me the total number of passenger cars that are using diesel in each canton?
+SELECT S.name, S.spatialunit_ontology,T.fuel_type, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE  S.canton=True and T.fuel_type ilike '%diesel%' and T.vehicle_type ='passenger_cars' GROUP BY S.spatialunit_ontology, S.name,T.fuel_type;
+                             name spatialunit_ontology
+                    Canton Aargau               Canton
+                    Canton Aargau               Canton
+                    Canton Aargau               Canton
+                    Canton Geneva               Canton
+                    Canton Geneva               Canton
+                    Canton Geneva               Canton
+                Canton Graubünden               Canton
+                Canton Graubünden               Canton
+                Canton Graubünden               Canton
+                      Canton Jura               Canton
+                      Canton Jura               Canton
+                      Canton Jura               Canton
+                 Canton Neuchâtel               Canton
+                 Canton Neuchâtel               Canton
+                 Canton Neuchâtel               Canton
+                   Canton Thurgau               Canton
+                   Canton Thurgau               Canton
+                   Canton Thurgau               Canton
+                    Canton Ticino               Canton
+                    Canton Ticino               Canton
+                    Canton Ticino               Canton
+                    Canton Valais               Canton
+                    Canton Valais               Canton
+                    Canton Valais               Canton
+                      Canton Vaud               Canton
+                      Canton Vaud               Canton
+                      Canton Vaud               Canton
+ Canton of Appenzell Ausserrhoden               Canton
+ Canton of Appenzell Ausserrhoden               Canton
+ Canton of Appenzell Ausserrhoden               Canton
+  Canton of Appenzell Innerrhoden               Canton
+  Canton of Appenzell Innerrhoden               Canton
+  Canton of Appenzell Innerrhoden               Canton
+       Canton of Basel-Landschaft               Canton
+       Canton of Basel-Landschaft               Canton
+       Canton of Basel-Landschaft               Canton
+            Canton of Basel-Stadt               Canton
+            Canton of Basel-Stadt               Canton
+            Canton of Basel-Stadt               Canton
+                   Canton of Bern               Canton
+                   Canton of Bern               Canton
+                   Canton of Bern               Canton
+               Canton of Fribourg               Canton
+               Canton of Fribourg               Canton
+               Canton of Fribourg               Canton
+                 Canton of Glarus               Canton
+                 Canton of Glarus               Canton
+                 Canton of Glarus               Canton
+                Canton of Lucerne               Canton
+                Canton of Lucerne               Canton
+                Canton of Lucerne               Canton
+              Canton of Nidwalden               Canton
+              Canton of Nidwalden               Canton
+              Canton of Nidwalden               Canton
+               Canton of Obwalden               Canton
+               Canton of Obwalden               Canton
+               Canton of Obwalden               Canton
+           Canton of Schaffhausen               Canton
+           Canton of Schaffhausen               Canton
+           Canton of Schaffhausen               Canton
+                 Canton of Schwyz               Canton
+                 Canton of Schwyz               Canton
+                 Canton of Schwyz               Canton
+              Canton of Solothurn               Canton
+              Canton of Solothurn               Canton
+              Canton of Solothurn               Canton
+             Canton of St. Gallen               Canton
+             Canton of St. Gallen               Canton
+             Canton of St. Gallen               Canton
+                    Canton of Uri               Canton
+                    Canton of Uri               Canton
+                    Canton of Uri               Canton
+                    Canton of Zug               Canton
+                    Canton of Zug               Canton
+                    Canton of Zug               Canton
+                 Canton of Zurich               Canton
+                 Canton of Zurich               Canton
+                 Canton of Zurich               Canton
+                       fuel_type amount
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0
+                          Diesel      0
+  Diesel-electric: Normal-hybrid      0
+ Diesel-electric: Plug-in-hybrid      0

--- a/pipelines/B1/queries.sql
+++ b/pipelines/B1/queries.sql
@@ -213,3 +213,39 @@ WHERE su.name = 'Switzerland'
     AND sv.vehicle_type = 'industrial vehicles'
     AND sv.fuel_type = 'Diesel'
     AND sv.year = 2013;
+
+-- How many vehicles do we have in canton zurich in 2020?
+SELECT S.name, sum(T.amount) as amount from stock_vehicles as T
+JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
+WHERE S.name ilike '%Zurich%'  and T.year=2020 and S.canton=True
+GROUP BY S.name;
+
+-- How many vehicles do we have in the city of zurich in 2021?
+SELECT S.name, S.spatialunit_ontology, sum(T.amount) as amount from stock_vehicles as T
+JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
+WHERE S.name ilike '%Z_rich%'  and T.year=2021 and S.municipal=True and T.fuel_type != 'total'
+GROUP BY S.name, S.spatialunit_ontology;
+
+-- How many vehicles do we have in zurich in 2020?
+SELECT S.name, S.spatialunit_ontology, sum(T.amount) as amount from stock_vehicles as T
+JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
+WHERE S.name ilike '%Z_rich%'  and T.year=2020 and (S.canton=True or S.municipal=True or S.district=True)
+GROUP BY S.name, S.spatialunit_ontology;
+
+-- How many electric cars do we have in the city of basel?
+SELECT S.name, S.spatialunit_ontology,T.fuel_type,T.year, sum(T.amount) as amount from stock_vehicles as T
+JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
+WHERE S.name ilike '%basel%'  and S.municipal=True and T.fuel_type ='Electric'
+GROUP BY S.spatialunit_ontology, S.name,T.fuel_type, T.year;
+
+-- How many hybrid cars do we have in the city of basel?
+SELECT S.name, S.spatialunit_ontology,T.fuel_type,T.year, sum(T.amount) as amount from stock_vehicles as T
+JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
+WHERE S.name ilike '%basel%'  and S.municipal=True and T.fuel_type ilike '%hybrid%'
+GROUP BY S.spatialunit_ontology, S.name,T.fuel_type, T.year;
+
+-- give me the total number of passenger cars that are using diesel in each canton?
+SELECT S.name, S.spatialunit_ontology,T.fuel_type, sum(T.amount) as amount from stock_vehicles as T
+JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
+WHERE  S.canton=True and T.fuel_type ilike '%diesel%' and T.vehicle_type ='passenger_cars'
+GROUP BY S.spatialunit_ontology, S.name,T.fuel_type;

--- a/pipelines/B6/queries.log
+++ b/pipelines/B6/queries.log
@@ -1,284 +1,30 @@
-[1] "Environment: REMOTE, Time: 2023-11-08 16:59:48"
+[1] "Environment: REMOTE, Time: 2023-11-23 18:35:04.793751"
 
 Query Nr. 1
--- How many vehicles do we have in canton zurich in 2020?
-SELECT S.name, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%Zurich%'  and T.year=2020 and S.canton=True GROUP BY S.name;
-             name  amount
- Canton of Zurich 2038628
-
-Query Nr. 2
--- How many vehicles do we have in the city of zurich in 2021?
-SELECT S.name, S.spatialunit_ontology, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%Z_rich%'  and T.year=2021 and S.municipal=True and T.fuel_type != 'total' GROUP BY S.name, S.spatialunit_ontology;
-   name spatialunit_ontology amount
- Zürich         Municipality 190773
-
-Query Nr. 3
--- How many vehicles do we have in zurich in 2020?
-SELECT S.name, S.spatialunit_ontology, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%Z_rich%'  and T.year=2020 and (S.canton=True or S.municipal=True or S.district=True) GROUP BY S.name, S.spatialunit_ontology;
-             name spatialunit_ontology  amount
-    Bezirk Zürich             District  381178
- Canton of Zurich               Canton 2038628
-           Zürich         Municipality  381178
-
-Query Nr. 4
--- How many electric cars do we have in the city of basel?
-SELECT S.name, S.spatialunit_ontology,T.fuel_type,T.year, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%basel%'  and S.municipal=True and T.fuel_type ='Electric' GROUP BY S.spatialunit_ontology, S.name,T.fuel_type, T.year;
-  name spatialunit_ontology fuel_type year amount
- Basel         Municipality  Electric 2010    100
- Basel         Municipality  Electric 2011    106
- Basel         Municipality  Electric 2012    122
- Basel         Municipality  Electric 2013    138
- Basel         Municipality  Electric 2014    168
- Basel         Municipality  Electric 2015    200
- Basel         Municipality  Electric 2016    245
- Basel         Municipality  Electric 2017    295
- Basel         Municipality  Electric 2018    372
- Basel         Municipality  Electric 2019    538
- Basel         Municipality  Electric 2020    767
- Basel         Municipality  Electric 2021   1121
-
-Query Nr. 5
--- How many hybrid cars do we have in the city of basel?
-SELECT S.name, S.spatialunit_ontology,T.fuel_type,T.year, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE S.name ilike '%basel%'  and S.municipal=True and T.fuel_type ilike '%hybrid%' GROUP BY S.spatialunit_ontology, S.name,T.fuel_type, T.year;
-  name spatialunit_ontology                        fuel_type year amount
- Basel         Municipality  Benzine-electric: Normal-hybrid 2010    279
- Basel         Municipality  Benzine-electric: Normal-hybrid 2011    333
- Basel         Municipality  Benzine-electric: Normal-hybrid 2012    393
- Basel         Municipality  Benzine-electric: Normal-hybrid 2013    504
- Basel         Municipality  Benzine-electric: Normal-hybrid 2014    567
- Basel         Municipality  Benzine-electric: Normal-hybrid 2015    604
- Basel         Municipality  Benzine-electric: Normal-hybrid 2016    716
- Basel         Municipality  Benzine-electric: Normal-hybrid 2017    791
- Basel         Municipality  Benzine-electric: Normal-hybrid 2018    864
- Basel         Municipality  Benzine-electric: Normal-hybrid 2019   1006
- Basel         Municipality  Benzine-electric: Normal-hybrid 2020   1245
- Basel         Municipality  Benzine-electric: Normal-hybrid 2021   1755
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2010      0
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2011      0
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2012      1
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2013      3
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2014      4
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2015     18
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2016     36
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2017     65
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2018    103
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2019    183
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2020    430
- Basel         Municipality Benzine-electric: Plug-in-hybrid 2021    518
- Basel         Municipality   Diesel-electric: Normal-hybrid 2010      1
- Basel         Municipality   Diesel-electric: Normal-hybrid 2011      3
- Basel         Municipality   Diesel-electric: Normal-hybrid 2012      7
- Basel         Municipality   Diesel-electric: Normal-hybrid 2013     15
- Basel         Municipality   Diesel-electric: Normal-hybrid 2014     20
- Basel         Municipality   Diesel-electric: Normal-hybrid 2015     27
- Basel         Municipality   Diesel-electric: Normal-hybrid 2016     28
- Basel         Municipality   Diesel-electric: Normal-hybrid 2017     33
- Basel         Municipality   Diesel-electric: Normal-hybrid 2018     44
- Basel         Municipality   Diesel-electric: Normal-hybrid 2019     95
- Basel         Municipality   Diesel-electric: Normal-hybrid 2020    193
- Basel         Municipality   Diesel-electric: Normal-hybrid 2021    437
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2010      0
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2011      0
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2012      0
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2013      1
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2014      2
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2015      3
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2016      4
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2017      6
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2018      3
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2019      3
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2020      5
- Basel         Municipality  Diesel-electric: Plug-in-hybrid 2021     11
-
-Query Nr. 6
--- give me the total number of passenger cars that are using diesel in each canton?
-SELECT S.name, S.spatialunit_ontology,T.fuel_type, sum(T.amount) as amount from stock_vehicles as T JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid WHERE  S.canton=True and T.fuel_type ilike '%diesel%' and T.vehicle_type ='passenger_cars' GROUP BY S.spatialunit_ontology, S.name,T.fuel_type;
-                             name spatialunit_ontology
-                    Canton Aargau               Canton
-                    Canton Aargau               Canton
-                    Canton Aargau               Canton
-                    Canton Geneva               Canton
-                    Canton Geneva               Canton
-                    Canton Geneva               Canton
-                Canton Graubünden               Canton
-                Canton Graubünden               Canton
-                Canton Graubünden               Canton
-                      Canton Jura               Canton
-                      Canton Jura               Canton
-                      Canton Jura               Canton
-                 Canton Neuchâtel               Canton
-                 Canton Neuchâtel               Canton
-                 Canton Neuchâtel               Canton
-                   Canton Thurgau               Canton
-                   Canton Thurgau               Canton
-                   Canton Thurgau               Canton
-                    Canton Ticino               Canton
-                    Canton Ticino               Canton
-                    Canton Ticino               Canton
-                    Canton Valais               Canton
-                    Canton Valais               Canton
-                    Canton Valais               Canton
-                      Canton Vaud               Canton
-                      Canton Vaud               Canton
-                      Canton Vaud               Canton
- Canton of Appenzell Ausserrhoden               Canton
- Canton of Appenzell Ausserrhoden               Canton
- Canton of Appenzell Ausserrhoden               Canton
-  Canton of Appenzell Innerrhoden               Canton
-  Canton of Appenzell Innerrhoden               Canton
-  Canton of Appenzell Innerrhoden               Canton
-       Canton of Basel-Landschaft               Canton
-       Canton of Basel-Landschaft               Canton
-       Canton of Basel-Landschaft               Canton
-            Canton of Basel-Stadt               Canton
-            Canton of Basel-Stadt               Canton
-            Canton of Basel-Stadt               Canton
-                   Canton of Bern               Canton
-                   Canton of Bern               Canton
-                   Canton of Bern               Canton
-               Canton of Fribourg               Canton
-               Canton of Fribourg               Canton
-               Canton of Fribourg               Canton
-                 Canton of Glarus               Canton
-                 Canton of Glarus               Canton
-                 Canton of Glarus               Canton
-                Canton of Lucerne               Canton
-                Canton of Lucerne               Canton
-                Canton of Lucerne               Canton
-              Canton of Nidwalden               Canton
-              Canton of Nidwalden               Canton
-              Canton of Nidwalden               Canton
-               Canton of Obwalden               Canton
-               Canton of Obwalden               Canton
-               Canton of Obwalden               Canton
-           Canton of Schaffhausen               Canton
-           Canton of Schaffhausen               Canton
-           Canton of Schaffhausen               Canton
-                 Canton of Schwyz               Canton
-                 Canton of Schwyz               Canton
-                 Canton of Schwyz               Canton
-              Canton of Solothurn               Canton
-              Canton of Solothurn               Canton
-              Canton of Solothurn               Canton
-             Canton of St. Gallen               Canton
-             Canton of St. Gallen               Canton
-             Canton of St. Gallen               Canton
-                    Canton of Uri               Canton
-                    Canton of Uri               Canton
-                    Canton of Uri               Canton
-                    Canton of Zug               Canton
-                    Canton of Zug               Canton
-                    Canton of Zug               Canton
-                 Canton of Zurich               Canton
-                 Canton of Zurich               Canton
-                 Canton of Zurich               Canton
-                       fuel_type amount
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-                          Diesel      0
-  Diesel-electric: Normal-hybrid      0
- Diesel-electric: Plug-in-hybrid      0
-
-Query Nr. 7
--- How many of the permanent population of Switzerlan have been born Aborad on the year of 2020?
+-- How many of the permanent population of Switzerland have been born Aborad on the year of 2020?
 SELECT T1.year, T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2020 AND T1.population_type ='Permanent resident population' AND T1.place_of_birth ='Abroad' AND T1.citizenship='Citizenship - total';
  year               population_type place_of_birth         citizenship  amount
  2020 Permanent resident population         Abroad Citizenship - total 2630432
 
-Query Nr. 8
+Query Nr. 2
 -- How many individuals with Swiss permanent residency were born within the country's borders on 2006?
 SELECT T1.year,T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2019 AND T1.population_type ='Permanent resident population' AND T1.place_of_birth ='Switzerland' AND T1.citizenship='Citizenship - total';
  year               population_type place_of_birth         citizenship  amount
  2019 Permanent resident population    Switzerland Citizenship - total 6015994
 
-Query Nr. 9
+Query Nr. 3
 -- In year 2019, how many individuals in Switzerland's permanent population were not born within the country's territory?
 SELECT T1.year, T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2019 AND T1.population_type ='Permanent resident population' AND T1.place_of_birth ='Abroad' AND T1.citizenship='Citizenship - total';
  year               population_type place_of_birth         citizenship  amount
  2019 Permanent resident population         Abroad Citizenship - total 2590039
 
-Query Nr. 10
+Query Nr. 4
 -- In 2021, how many people were living in Switzerland who were not born there and did not have permanent residency?
 SELECT T1.year,T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2021 AND T1.population_type ='Non permanent resident population' AND T1.place_of_birth ='Abroad' AND T1.citizenship='Citizenship - total';
- year                   population_type place_of_birth         citizenship
- 2021 Non permanent resident population         Abroad Citizenship - total
- amount
-  65129
+ year                   population_type place_of_birth         citizenship amount
+ 2021 Non permanent resident population         Abroad Citizenship - total  65129
 
-Query Nr. 11
+Query Nr. 5
 -- Can you provide a breakdown of the number of people who hold Swiss permanent residency and were born in Switzerland in 2020, categorized by their respective citizenships?
 SELECT T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2020 AND T1.population_type ='Permanent resident population' AND T1.place_of_birth ='Switzerland' AND T1.citizenship !='Citizenship - total';
                population_type place_of_birth
@@ -485,164 +231,163 @@ SELECT T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resid
  Permanent resident population    Switzerland
  Permanent resident population    Switzerland
                                    citizenship  amount
-                                         Palau       0
-                                   Afghanistan    1965
                                        Nigeria     395
                                         Kosovo   35519
-                                       Czechia     899
+                                   Afghanistan    1965
+                                   El Salvador      14
                                         Sweden    1078
+                                       Czechia     899
                                          Japan     278
                                          Haiti      43
-                         São Tomé and Príncipe       0
-                                       Germany   39484
-                                   El Salvador      14
-                                      Pakistan     505
                                        Morocco     910
+                         São Tomé and Príncipe       0
+                                      Pakistan     505
+                                       Comoros       1
+                                       Germany   39484
                                     Uzbekistan      42
               Saint Vincent and the Grenadines       1
                                    Timor-Leste       0
                                     Tajikistan       9
                                      Palestine      40
                                          Nauru       0
-                                       Comoros       1
-                                      Maldives       3
-                                       Belgium    1754
-                                       Romania    1756
+                       Taiwan (Chinese Taipei)      28
                                    Netherlands    3001
-                                       Armenia      72
                                        Grenada       0
+                                      Suriname       0
+                                         Kenya     161
+                                         Libya     179
+                                     Mauritius      83
+                                       Belgium    1754
+                                      Maldives       3
+                                       Armenia      72
+                                       Romania    1756
                            Trinidad and Tobago       1
                                         Jordan      59
-                                         Kenya     161
-                                      Suriname       0
-                                     Mauritius      83
-                                        Guinea     141
-                                         Libya     179
                                          Benin      40
-                                          Laos      31
-                       Taiwan (Chinese Taipei)      28
-                                       Iceland      50
+                                        Guinea     141
                                        Denmark     552
+                                       Iceland      50
                                       Barbados       1
-                                        Uganda      44
+                                          Laos      31
+                                    Montenegro     654
                                           Cuba      47
                                         Norway     303
                                        Belarus      93
-                                      Thailand     362
                                          Italy   97016
-                                        Serbia   16352
-                                        Panama       5
-                           Congo (Brazzaville)     123
                                        Vietnam     516
-                                      Tanzania      30
-                             Equatorial Guinea       5
+                           Congo (Brazzaville)     123
                                        Myanmar       8
                                   Saudi Arabia      44
                                        Albania     352
-                                    Montenegro     654
+                                      Thailand     362
+                                        Uganda      44
+                                        Serbia   16352
+                                        Panama       5
+                             Equatorial Guinea       5
+                                      Tanzania      30
                                         Turkey   19558
-                                         Ghana     244
-                                          Togo     251
                                        Burundi      32
-                                    Kyrgyzstan      21
+                                          Togo     251
                                       Slovakia    1802
- Not attributable according to current borders       0
+                                         Ghana     244
                             Dominican Republic     672
+ Not attributable according to current borders       0
+                                       Algeria     664
+                              Congo (Kinshasa)    1668
                                        Hungary    2201
+                                       Finland     463
                                        Andorra       2
                                        Eritrea   10701
                                       Cambodia     172
+                                 No indication     553
                                       Dominica       1
                                           Peru     174
-                                       Algeria     664
-                              Congo (Kinshasa)    1668
-                                       Finland     463
-                                 No indication     553
+                                    Kyrgyzstan      21
                                           Fiji       1
-                                       Uruguay      18
                                         Cyprus      48
-                                  Vatican City       0
+                                       Uruguay      18
                                      Nicaragua      33
-                                    Kazakhstan      53
                                     Cabo Verde     188
+                                  Vatican City       0
+                                    Kazakhstan      53
                                         Zambia       9
                                     Micronesia       0
                                          Malta      22
                                      Argentina      76
-                                        Mexico     111
-                                  Burkina Faso      39
-                                       Ireland     570
-                                   North Korea       2
                                          Syria    3274
+                                   North Korea       2
+                                  Burkina Faso      39
+                                        Mexico     111
+                                       Ireland     570
                                        Tunisia    1484
-                                         Chile     433
-                                          Iraq    1646
-                                    Azerbaijan      74
                                         Kuwait       7
+                                    Azerbaijan      74
+                                          Iraq    1646
+                                      Malaysia     102
+                                         Chile     433
                                     San Marino       7
                                        Senegal     176
-                                      Malaysia     102
+                                Western Sahara       2
                                        Bahamas       0
                           United Arab Emirates       2
-                                      Mongolia     150
-                                Western Sahara       2
-                                     Indonesia     108
-                                       Jamaica      26
-                                       Lesotho       1
-                                       Namibia       8
-                                   South Sudan       4
                                   South Africa     139
+                                     Indonesia     108
+                                       Lesotho       1
+                                   South Sudan       4
+                                       Jamaica      26
+                                         Samoa       2
+                                       Namibia       8
                                  United States    1172
+                                        Israel     107
+                                    Costa Rica      12
+                                      Mongolia     150
                                           Iran     508
                                   Turkmenistan       1
-                                        Israel     107
                                        Somalia    2306
-                                    Costa Rica      12
                                        Estonia      90
                                      Singapore      35
-                                         Samoa       2
                                          Gabon       7
-                                       Liberia      17
-                                        Guyana       2
                                  Côte d'Ivoire     264
+                                        Guyana       2
                                        Bolivia     268
                               Marshall Islands       0
+                                       Liberia      17
                                         Gambia      54
                                       Botswana       1
                                       Paraguay      27
-                                       Ecuador     302
+                                        Canada     599
                                    Switzerland 5612417
                                  Liechtenstein     885
-                                        Canada     599
-                                        Brazil    1562
-                                United Kingdom    4796
                                       Bulgaria     895
+                                       Ecuador     302
                                     Luxembourg     152
+                                        Brazil    1562
                                      Sri Lanka    6656
                                       Djibouti       7
-                                    Seychelles       8
+                                        France   18958
                                   Sierra Leone      34
+                                United Kingdom    4796
+                                        Malawi       6
+                                    Seychelles       8
+                                        Belize       0
                                       Portugal   55984
                                          Qatar       0
                                        Ukraine     328
                                  Guinea-Bissau      16
                                        Bahrain       2
-                                        Malawi       6
-                                        France   18958
                                      Stateless      89
-                                        Belize       0
                                          China    1990
                                         Tuvalu       0
                                    South Korea      87
                       Central African Republic       6
-                                        Poland    3570
-                                   Philippines     489
-                                       Vanuatu       0
-                                        Latvia     244
-                                        Rwanda      55
                                       Slovenia    1176
+                                   Philippines     489
+                                        Poland    3570
+                                        Latvia     244
                                       Eswatini       0
                                   Cook Islands       0
+                                        Rwanda      55
+                                       Vanuatu       0
                                     Bangladesh     314
                                          Yemen     100
                                     Mauritania       3
@@ -655,4398 +400,406 @@ SELECT T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resid
                                         Russia    1285
                                Solomon Islands       1
                            Antigua and Barbuda       1
-                                         Egypt     229
-                                         Tonga       0
-                                          Oman       6
-                                     Guatemala      18
-                                       Lebanon     259
                                      Venezuela      43
+                                         Egypt     229
+                                          Oman       6
                         Bosnia and Herzegovina    6319
+                                         Tonga       0
+                                     Guatemala      18
                                       Kiribati       0
+                                       Lebanon     259
                                North Macedonia   19964
+                                   Saint Lucia       0
                                      Australia     220
                                         Greece    1928
-                              Papua New Guinea       0
-                                   Saint Lucia       0
+                                       Georgia      75
                                    New Zealand      67
                                     Mozambique       6
                                         Angola     820
                                       Colombia     291
-                                       Georgia      75
+                              Papua New Guinea       0
                                           Mali      20
-                                         Spain   20714
-                                      Cameroon     648
                                         Bhutan       2
                                          Nepal      50
+                                      Cameroon     648
+                                         Spain   20714
                                       Honduras      20
-                                        Brunei       0
-                                          Chad      17
                                     Madagascar      41
-                                         Niger      10
+                                          Chad      17
                                       Zimbabwe      28
+                                        Brunei       0
+                                         Niger      10
                                          India    1801
-                                     Lithuania     213
                                          Sudan     154
+                                         Palau       0
+                                     Lithuania     213
 
-Query Nr. 12
+Query Nr. 6
 -- What was the percentage of the population in Switerland who were born in a foreign country on 2017?
 SELECT sum(un.in), sum(un.out) , sum(un.out)/(sum(un.in)+sum(un.out)) AS percentage FROM (SELECT T1.year,T1.place_of_birth,T1.citizenship, Sum(T1.amount) as in, sum(0) as out  from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2017  AND T1.place_of_birth ='Switzerland' AND T1.citizenship='Citizenship - total' GROUP BY T1.year,  T1.place_of_birth, T1.citizenship UNION SELECT T1.year,T1.place_of_birth,T1.citizenship, sum(0) as in, Sum(T1.amount) as out from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2017  AND T1.place_of_birth ='Abroad' AND T1.citizenship='Citizenship - total' GROUP BY T1.year, T1.place_of_birth, T1.citizenship ) AS un;
      sum  sum..2 percentage
  5966793 2593358   0.302957
 
-Query Nr. 13
+Query Nr. 7
 -- In 2021, what percentage of the population in Switzerland consisted of individuals who were born within the country's borders?
 SELECT un.in, un.out , un.in/(un.in+un.out) AS percentage FROM (SELECT T1.year,T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount as in, 0 as out from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2001 AND T1.population_type ='total' AND T1.place_of_birth ='Switzerland' AND T1.citizenship='Citizenship - total' UNION SELECT T1.year,T1.population_type,T1.place_of_birth,T1.citizenship, 0 as in, T1.amount as out from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True AND T1.year=2001 AND T1.population_type ='total' AND T1.place_of_birth ='Abroad' AND T1.citizenship='Citizenship - total' ) AS un;
 [1] in         out        percentage
 <0 rows> (or 0-length row.names)
 
-Query Nr. 14
+Query Nr. 8
 -- In 2020, what was the number of individuals categorized as non-permanent residents in the Canton of Zug?
 SELECT T1.year,T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.canton=True AND T2.name ilike '%Zug%' AND T1.year=2020 AND T1.population_type ='Non permanent resident population' AND T1.place_of_birth ='Place of birth - total' AND T1.citizenship='Citizenship - total';
- year                   population_type         place_of_birth
- 2020 Non permanent resident population Place of birth - total
-         citizenship amount
- Citizenship - total   1360
+ year                   population_type         place_of_birth         citizenship
+ 2020 Non permanent resident population Place of birth - total Citizenship - total
+ amount
+   1360
 
-Query Nr. 15
+Query Nr. 9
 -- How many of the people were born abroad in municipality level  had the permanent residenship on 2010?
 SELECT T1.year, T2.spatialunit_ontology, T2.name, T1.population_type,T1.place_of_birth, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.municipal=True  AND T1.year=2010 AND T1.population_type ='Permanent resident population' AND T1.place_of_birth ='Abroad' AND T1.citizenship='Citizenship - total';
- year spatialunit_ontology                        name
- 2010         Municipality                     Homburg
- 2010         Municipality                       Jenaz
- 2010         Municipality              Erlenbach (ZH)
- 2010         Municipality                    Scheuren
- 2010         Municipality                   Morschach
- 2010         Municipality                Corsier (GE)
- 2010         Municipality                   Pfäffikon
- 2010         Municipality                     Tévenon
- 2010         Municipality                     Meyriez
- 2010         Municipality              Twann-Tüscherz
- 2010         Municipality                 Oberembrach
- 2010         Municipality                   Champvent
- 2010         Municipality                       Court
- 2010         Municipality                   Lavizzara
- 2010         Municipality                   Gempenach
- 2010         Municipality                    Düdingen
- 2010         Municipality                   Cortébert
- 2010         Municipality                       Frick
- 2010         Municipality             Laufen-Uhwiesen
- 2010         Municipality                       Orges
- 2010         Municipality                    Wil (ZH)
- 2010         Municipality                        Lyss
- 2010         Municipality                        Root
- 2010         Municipality                Schaffhausen
- 2010         Municipality                    Hochwald
- 2010         Municipality                       Grens
- 2010         Municipality                    Scharans
- 2010         Municipality          Collonge-Bellerive
- 2010         Municipality                    Boningen
- 2010         Municipality                     Bözberg
- 2010         Municipality                    Ménières
- 2010         Municipality                       Flims
- 2010         Municipality           Obersaxen Mundaun
- 2010         Municipality                 Radelfingen
- 2010         Municipality                   Burg (AG)
- 2010         Municipality                       Sauge
- 2010         Municipality                   Echichens
- 2010         Municipality                    Mägenwil
- 2010         Municipality                      Sergey
- 2010         Municipality               Cressier (NE)
- 2010         Municipality              Full-Reuenthal
- 2010         Municipality               Jorat-Menthue
- 2010         Municipality                  Altstätten
- 2010         Municipality                     Dachsen
- 2010         Municipality             Arzier-Le Muids
- 2010         Municipality                      Gsteig
- 2010         Municipality              Hauterive (NE)
- 2010         Municipality                    Brissago
- 2010         Municipality                     Bennwil
- 2010         Municipality                  Vullierens
- 2010         Municipality                   Curtilles
- 2010         Municipality                      Lupfig
- 2010         Municipality                 Romont (FR)
- 2010         Municipality                      Fiesch
- 2010         Municipality                  Les Enfers
- 2010         Municipality                      Uznach
- 2010         Municipality                     Aarberg
- 2010         Municipality                      Falera
- 2010         Municipality              Arnex-sur-Nyon
- 2010         Municipality                       Gimel
- 2010         Municipality                     Breggia
- 2010         Municipality                       Grono
- 2010         Municipality                      Morlon
- 2010         Municipality                    Röschenz
- 2010         Municipality                 Oberhünigen
- 2010         Municipality                   Rüti (ZH)
- 2010         Municipality           Beinwil (Freiamt)
- 2010         Municipality                    Eptingen
- 2010         Municipality                      Heiden
- 2010         Municipality               Thalheim (AG)
- 2010         Municipality                     Aristau
- 2010         Municipality                      Mühlau
- 2010         Municipality                    Schongau
- 2010         Municipality                       Scuol
- 2010         Municipality                      Aadorf
- 2010         Municipality                 Chêne-Bourg
- 2010         Municipality          Muntogna da Schons
- 2010         Municipality                 Derendingen
- 2010         Municipality                   Domleschg
- 2010         Municipality                   Bubendorf
- 2010         Municipality              Unterentfelden
- 2010         Municipality         Escholzmatt-Marbach
- 2010         Municipality                Grossdietwil
- 2010         Municipality                   Belprahon
- 2010         Municipality                      Urdorf
- 2010         Municipality                      Hallau
- 2010         Municipality                         Rue
- 2010         Municipality                   Göschenen
- 2010         Municipality        Bichelsee-Balterswil
- 2010         Municipality                  Miglieglia
- 2010         Municipality                     Zäziwil
- 2010         Municipality                    Pratteln
- 2010         Municipality                       Borex
- 2010         Municipality                   Novazzano
- 2010         Municipality                      Jaberg
- 2010         Municipality                     Rheinau
- 2010         Municipality                    Aefligen
- 2010         Municipality                  Roggliswil
- 2010         Municipality                Strengelbach
- 2010         Municipality            Villars-le-Comte
- 2010         Municipality                  Beckenried
- 2010         Municipality                  Rothenburg
- 2010         Municipality                   Fürstenau
- 2010         Municipality                Bischofszell
- 2010         Municipality                     Bättwil
- 2010         Municipality                     Fideris
- 2010         Municipality                  Gächlingen
- 2010         Municipality                 Wiedlisbach
- 2010         Municipality           Saint-Martin (FR)
- 2010         Municipality                     Hellsau
- 2010         Municipality                    Massagno
- 2010         Municipality                      Prilly
- 2010         Municipality                Carouge (GE)
- 2010         Municipality                      Grancy
- 2010         Municipality                     Uttigen
- 2010         Municipality                Roggwil (TG)
- 2010         Municipality                    Valbroye
- 2010         Municipality                      Ebikon
- 2010         Municipality                  Wisen (SO)
- 2010         Municipality                 Hausen (AG)
- 2010         Municipality                    Gruyères
- 2010         Municipality                  Gaiserwald
- 2010         Municipality                      Inkwil
- 2010         Municipality                     Wolfwil
- 2010         Municipality                  Oberhallau
- 2010         Municipality                   Rorschach
- 2010         Municipality               Oberriet (SG)
- 2010         Municipality              Kirchberg (SG)
- 2010         Municipality                    Evionnaz
- 2010         Municipality               Haut-Intyamon
- 2010         Municipality                  Rossinière
- 2010         Municipality                  Jegenstorf
- 2010         Municipality                     Urnäsch
- 2010         Municipality                       Kerns
- 2010         Municipality                     Muzzano
- 2010         Municipality                     Allaman
- 2010         Municipality                      Vétroz
- 2010         Municipality           Plateau de Diesse
- 2010         Municipality                       Anwil
- 2010         Municipality                    Bäriswil
- 2010         Municipality                      Gonten
- 2010         Municipality                       Avusy
- 2010         Municipality                    Hedingen
- 2010         Municipality                 Schmiedrued
- 2010         Municipality                   Plaffeien
- 2010         Municipality              Forel (Lavaux)
- 2010         Municipality                      Rorbas
- 2010         Municipality                       Spiez
- 2010         Municipality                   Neckertal
- 2010         Municipality                   Meltingen
- 2010         Municipality            La Côte-aux-Fées
- 2010         Municipality                    Oekingen
- 2010         Municipality                       Agiez
- 2010         Municipality                    Boltigen
- 2010         Municipality                   Muntelier
- 2010         Municipality                Gontenschwil
- 2010         Municipality                      Urmein
- 2010         Municipality             Jouxtens-Mézery
- 2010         Municipality                       Realp
- 2010         Municipality                   Fällanden
- 2010         Municipality                 Schönenbuch
- 2010         Municipality                 Corminboeuf
- 2010         Municipality             Medel (Lucmagn)
- 2010         Municipality                Bas-Intyamon
- 2010         Municipality                   Hagenbuch
- 2010         Municipality        Essertines-sur-Rolle
- 2010         Municipality                    Frutigen
- 2010         Municipality                   Hohenrain
- 2010         Municipality            Teuffenthal (BE)
- 2010         Municipality                  Hauteville
- 2010         Municipality                Ebnat-Kappel
- 2010         Municipality                      Bülach
- 2010         Municipality           Villars-sur-Glâne
- 2010         Municipality                     Juriens
- 2010         Municipality               Grandfontaine
- 2010         Municipality                 Gsteigwiler
- 2010         Municipality                   Ottenbach
- 2010         Municipality                  Bourrignon
- 2010         Municipality         Kradolf-Schönenberg
- 2010         Municipality                       Curio
- 2010         Municipality                Oberwil (BL)
- 2010         Municipality                   Onsernone
- 2010         Municipality                    Salgesch
- 2010         Municipality                    Reutigen
- 2010         Municipality                 Saules (BE)
- 2010         Municipality      Erlenbach im Simmental
- 2010         Municipality                   Landquart
- 2010         Municipality                       Aarau
- 2010         Municipality             Walterswil (SO)
- 2010         Municipality                      Rances
- 2010         Municipality                      Horgen
- 2010         Municipality          Saint-Sulpice (VD)
- 2010         Municipality              Le Bémont (JU)
- 2010         Municipality                      Naters
- 2010         Municipality                    Semsales
- 2010         Municipality                 Wölflinswil
- 2010         Municipality       La Chaux-des-Breuleux
- 2010         Municipality                   Anniviers
- 2010         Municipality                Grandvillard
- 2010         Municipality                     Origlio
- 2010         Municipality                   Mauborget
- 2010         Municipality                    Linescio
- 2010         Municipality                       Soral
- 2010         Municipality                   Innerthal
- 2010         Municipality          Mümliswil-Ramiswil
- 2010         Municipality                   Penthalaz
- 2010         Municipality                  Roggenburg
- 2010         Municipality                   Stansstad
- 2010         Municipality                     Wittnau
- 2010         Municipality                    Mauensee
- 2010         Municipality                      Winkel
- 2010         Municipality                     Sommeri
- 2010         Municipality                       Bözen
- 2010         Municipality              Buch am Irchel
- 2010         Municipality                 Fischenthal
- 2010         Municipality                 Niederglatt
- 2010         Municipality                       Missy
- 2010         Municipality         Seewis im Prättigau
- 2010         Municipality          Villars-le-Terroir
- 2010         Municipality                  Gottlieben
- 2010         Municipality                       Eiken
- 2010         Municipality                      Hinwil
- 2010         Municipality                     La Tène
- 2010         Municipality                Albula/Alvra
- 2010         Municipality              Pierrafortscha
- 2010         Municipality                     Cornaux
- 2010         Municipality                       Dalpe
- 2010         Municipality                       Mumpf
- 2010         Municipality            Rüti bei Lyssach
- 2010         Municipality                  St. Gallen
- 2010         Municipality                     Kesswil
- 2010         Municipality                     Adlikon
- 2010         Municipality                    Bussigny
- 2010         Municipality                     Le Flon
- 2010         Municipality                      Luzein
- 2010         Municipality           Vugelles-La Mothe
- 2010         Municipality                 Gretzenbach
- 2010         Municipality                 Schafisheim
- 2010         Municipality                    Wollerau
- 2010         Municipality                       Dully
- 2010         Municipality                      Ramsen
- 2010         Municipality                   Seegräben
- 2010         Municipality     Wildhaus-Alt St. Johann
- 2010         Municipality                    Ettiswil
- 2010         Municipality        Romanel-sur-Lausanne
- 2010         Municipality                     Saillon
- 2010         Municipality                L'Abergement
- 2010         Municipality                     Bürchen
- 2010         Municipality              Châtillon (FR)
- 2010         Municipality             Chêne-Bougeries
- 2010         Municipality                    Treyvaux
- 2010         Municipality                    Eischoll
- 2010         Municipality                Vendlincourt
- 2010         Municipality                  Degersheim
- 2010         Municipality        Belmont-sur-Lausanne
- 2010         Municipality                   Hüttwilen
- 2010         Municipality                      Andeer
- 2010         Municipality               Saint-Léonard
- 2010         Municipality                    Eggenwil
- 2010         Municipality                     Finhaut
- 2010         Municipality                     Sevelen
- 2010         Municipality                     Samnaun
- 2010         Municipality                   Gansingen
- 2010         Municipality                        Buus
- 2010         Municipality                    Ponthaux
- 2010         Municipality                    Humlikon
- 2010         Municipality                 Mörel-Filet
- 2010         Municipality                    Les Bois
- 2010         Municipality                      Leysin
- 2010         Municipality              Münchenbuchsee
- 2010         Municipality                  Montanaire
- 2010         Municipality                    Sachseln
- 2010         Municipality                   Menzingen
- 2010         Municipality            Aeschi bei Spiez
- 2010         Municipality                    Tenniken
- 2010         Municipality                      Vinelz
- 2010         Municipality                     La Praz
- 2010         Municipality                       Faoug
- 2010         Municipality                   Cadempino
- 2010         Municipality                   Personico
- 2010         Municipality                     Wattwil
- 2010         Municipality                     Herdern
- 2010         Municipality                    Hüttikon
- 2010         Municipality                    Rietheim
- 2010         Municipality                          Gy
- 2010         Municipality               Troistorrents
- 2010         Municipality               Schwarzenberg
- 2010         Municipality                   Schlieren
- 2010         Municipality                      Erlach
- 2010         Municipality                  Grandevent
- 2010         Municipality                  Tentlingen
- 2010         Municipality                 Willadingen
- 2010         Municipality                     Kaisten
- 2010         Municipality                        Nods
- 2010         Municipality                     Ferrera
- 2010         Municipality                    Boniswil
- 2010         Municipality                    Bursinel
- 2010         Municipality                        Mels
- 2010         Municipality                       Lonay
- 2010         Municipality                    Montreux
- 2010         Municipality                    Herznach
- 2010         Municipality             Erlinsbach (SO)
- 2010         Municipality                    Pollegio
- 2010         Municipality                      Sursee
- 2010         Municipality                   Bärschwil
- 2010         Municipality            Tobel-Tägerschen
- 2010         Municipality                 Courrendlin
- 2010         Municipality                        Avry
- 2010         Municipality                      Sulgen
- 2010         Municipality                     Malters
- 2010         Municipality         Ellikon an der Thur
- 2010         Municipality                  Dürrenroth
- 2010         Municipality                Münchenwiler
- 2010         Municipality                    Grandval
- 2010         Municipality                     Habkern
- 2010         Municipality                    Crissier
- 2010         Municipality                  Rifferswil
- 2010         Municipality                    Crémines
- 2010         Municipality                  Hettlingen
- 2010         Municipality                    Attalens
- 2010         Municipality                   Iseltwald
- 2010         Municipality                     Mandach
- 2010         Municipality                       Rolle
- 2010         Municipality                     Eschenz
- 2010         Municipality                    Cartigny
- 2010         Municipality                    Hölstein
- 2010         Municipality                 Monteceneri
- 2010         Municipality                   Leukerbad
- 2010         Municipality                      Losone
- 2010         Municipality                      Mauraz
- 2010         Municipality                   Isérables
- 2010         Municipality        Walliswil bei Wangen
- 2010         Municipality                    Longirod
- 2010         Municipality             Erlinsbach (AG)
- 2010         Municipality                   Echallens
- 2010         Municipality                   Unterseen
- 2010         Municipality               Clos du Doubs
- 2010         Municipality                 San Vittore
- 2010         Municipality                   Safiental
- 2010         Municipality                Lichtensteig
- 2010         Municipality                        Laax
- 2010         Municipality                  Grangettes
- 2010         Municipality                    Gachnang
- 2010         Municipality                       Basel
- 2010         Municipality                 Froideville
- 2010         Municipality                  Lauperswil
- 2010         Municipality                      Zeihen
- 2010         Municipality                   Dallenwil
- 2010         Municipality                     Remigen
- 2010         Municipality                  Gebenstorf
- 2010         Municipality                 Saint-Oyens
- 2010         Municipality                       Torny
- 2010         Municipality                 Villnachern
- 2010         Municipality                    Courroux
- 2010         Municipality               Doppleschwand
- 2010         Municipality              Unterlunkhofen
- 2010         Municipality                      Kippel
- 2010         Municipality      Neuhausen am Rheinfall
- 2010         Municipality                    Grandson
- 2010         Municipality                  Eggersriet
- 2010         Municipality        Rüdtligen-Alchenflüh
- 2010         Municipality           Castel San Pietro
- 2010         Municipality          Châtel-Saint-Denis
- 2010         Municipality                  Märstetten
- 2010         Municipality                  Neuenkirch
- 2010         Municipality            Ried bei Kerzers
- 2010         Municipality                   Stallikon
- 2010         Municipality                 Remetschwil
- 2010         Municipality                    Novalles
- 2010         Municipality                  Wittenbach
- 2010         Municipality    Welschenrohr-Gänsbrunnen
- 2010         Municipality                  Niederbipp
- 2010         Municipality       Affoltern im Emmental
- 2010         Municipality           Wettswil am Albis
- 2010         Municipality                   Berg (TG)
- 2010         Municipality                      Valsot
- 2010         Municipality                     Bursins
- 2010         Municipality              Val-de-Charmey
- 2010         Municipality                Wegenstetten
- 2010         Municipality           Urtenen-Schönbühl
- 2010         Municipality        Sils im Engadin/Segl
- 2010         Municipality           Horrenbach-Buchen
- 2010         Municipality                    Chevilly
- 2010         Municipality              Péry-La Heutte
- 2010         Municipality                     Balerna
- 2010         Municipality                 Wigoltingen
- 2010         Municipality                     Veyrier
- 2010         Municipality              Hergiswil (NW)
- 2010         Municipality                  Rupperswil
- 2010         Municipality                 Préverenges
- 2010         Municipality                       Moiry
- 2010         Municipality        Le Mont-sur-Lausanne
- 2010         Municipality                   Sigriswil
- 2010         Municipality                       Wengi
- 2010         Municipality                       Orvin
- 2010         Municipality         Lüterswil-Gächliwil
- 2010         Municipality                   Ammerswil
- 2010         Municipality                  Nürensdorf
- 2010         Municipality                      Illgau
- 2010         Municipality                 Wittinsburg
- 2010         Municipality                    Fribourg
- 2010         Municipality                     Genthod
- 2010         Municipality                   Leissigen
- 2010         Municipality               Noble-Contrée
- 2010         Municipality              Montet (Glâne)
- 2010         Municipality                      Wauwil
- 2010         Municipality                        Gams
- 2010         Municipality                 Wachseldorn
- 2010         Municipality                Werthenstein
- 2010         Municipality                      Signau
- 2010         Municipality                 Biel/Bienne
- 2010         Municipality              Niederwil (AG)
- 2010         Municipality                      Surses
- 2010         Municipality                    Movelier
- 2010         Municipality                       Arbon
- 2010         Municipality                        Rain
- 2010         Municipality                 Clavaleyres
- 2010         Municipality              Villars-Epeney
- 2010         Municipality               Niederhünigen
- 2010         Municipality         Celerina/Schlarigna
- 2010         Municipality                   Hérémence
- 2010         Municipality                    Oppligen
- 2010         Municipality                    Rüttenen
- 2010         Municipality                   Pieterlen
- 2010         Municipality                Unterramsern
- 2010         Municipality                    Hemmiken
- 2010         Municipality                   St. Ursen
- 2010         Municipality                      Laufen
- 2010         Municipality                Schlatt (TG)
- 2010         Municipality         La Chaux (Cossonay)
- 2010         Municipality               Unterschächen
- 2010         Municipality                    Felsberg
- 2010         Municipality                   Römerswil
- 2010         Municipality                      Lalden
- 2010         Municipality               Veltheim (AG)
- 2010         Municipality                     Rueyres
- 2010         Municipality                    Lüscherz
- 2010         Municipality                      Paudex
- 2010         Municipality                  Buchs (AG)
- 2010         Municipality                Diessenhofen
- 2010         Municipality                   Wattenwil
- 2010         Municipality                  Rebévelier
- 2010         Municipality                      Russin
- 2010         Municipality                   Ursenbach
- 2010         Municipality                 Saint-Imier
- 2010         Municipality          La Punt Chamues-ch
- 2010         Municipality  Rudolfstetten-Friedlisberg
- 2010         Municipality                   Oberiberg
- 2010         Municipality            Ringgenberg (BE)
- 2010         Municipality                   Waldkirch
- 2010         Municipality                         Fey
- 2010         Municipality                      Lachen
- 2010         Municipality                    Thayngen
- 2010         Municipality                     Vacallo
- 2010         Municipality                     Luthern
- 2010         Municipality                     Le Vaud
- 2010         Municipality                        Croy
- 2010         Municipality                 Les Montets
- 2010         Municipality                        Pfyn
- 2010         Municipality                    Hellikon
- 2010         Municipality                      Pailly
- 2010         Municipality                   Hermrigen
- 2010         Municipality                     Lungern
- 2010         Municipality                        Vals
- 2010         Municipality                      Laupen
- 2010         Municipality         Les Ponts-de-Martel
- 2010         Municipality               Poliez-Pittet
- 2010         Municipality                      Lommis
- 2010         Municipality                 Bosco/Gurin
- 2010         Municipality        Le Cerneux-Péquignot
- 2010         Municipality                    Büetigen
- 2010         Municipality                   Rheinwald
- 2010         Municipality           Vufflens-la-Ville
- 2010         Municipality                 Laupersdorf
- 2010         Municipality                 Brienz (BE)
- 2010         Municipality            Saint-Aubin (FR)
- 2010         Municipality                       Vevey
- 2010         Municipality               Küsnacht (ZH)
- 2010         Municipality             Le Pâquier (FR)
- 2010         Municipality                  Hemishofen
- 2010         Municipality                Mollens (VD)
- 2010         Municipality                      Knonau
- 2010         Municipality        Bretigny-sur-Morrens
- 2010         Municipality                     Lavigny
- 2010         Municipality                    Hermance
- 2010         Municipality                     Chiasso
- 2010         Municipality                     Rümlang
- 2010         Municipality                  Feusisberg
- 2010         Municipality                    Speicher
- 2010         Municipality             Billens-Hennens
- 2010         Municipality                       Brügg
- 2010         Municipality                       Varen
- 2010         Municipality                    Leuzigen
- 2010         Municipality                      Jongny
- 2010         Municipality                    Adliswil
- 2010         Municipality                      Bavois
- 2010         Municipality                      Sorens
- 2010         Municipality                      Bernex
- 2010         Municipality                   Fontenais
- 2010         Municipality                     Nottwil
- 2010         Municipality                    Cossonay
- 2010         Municipality                    Arisdorf
- 2010         Municipality                Bürglen (TG)
- 2010         Municipality                    Tramelan
- 2010         Municipality                      Bonfol
- 2010         Municipality                Stetten (AG)
- 2010         Municipality                    Coinsins
- 2010         Municipality                 Rothenthurm
- 2010         Municipality                     Chalais
- 2010         Municipality                   Chavornay
- 2010         Municipality                   Rünenberg
- 2010         Municipality                      Chancy
- 2010         Municipality                       Augst
- 2010         Municipality                     Berikon
- 2010         Municipality             Lohn-Ammannsegg
- 2010         Municipality                 Le Noirmont
- 2010         Municipality                 Raperswilen
- 2010         Municipality                   Chardonne
- 2010         Municipality       Montagny-près-Yverdon
- 2010         Municipality                       Sévaz
- 2010         Municipality                    Mülligen
- 2010         Municipality                    Därligen
- 2010         Municipality                        Cama
- 2010         Municipality                      Ropraz
- 2010         Municipality                      Boudry
- 2010         Municipality           Burg im Leimental
- 2010         Municipality                    Dotzigen
- 2010         Municipality                   Donneloye
- 2010         Municipality                        Lenk
- 2010         Municipality                   Guttannen
- 2010         Municipality                Seedorf (BE)
- 2010         Municipality                  Rüschlikon
- 2010         Municipality                     Homberg
- 2010         Municipality                      Saanen
- 2010         Municipality                    Magliaso
- 2010         Municipality                   Domat/Ems
- 2010         Municipality                       Lutry
- 2010         Municipality                    Valbirse
- 2010         Municipality                    Paradiso
- 2010         Municipality                       Ernen
- 2010         Municipality                    Schwende
- 2010         Municipality                    Genolier
- 2010         Municipality                   Poschiavo
- 2010         Municipality                     Goldach
- 2010         Municipality                      Genève
- 2010         Municipality                   Eggerberg
- 2010         Municipality                   Waldstatt
- 2010         Municipality              Beinwil am See
- 2010         Municipality                     Savigny
- 2010         Municipality                        Pura
- 2010         Municipality                      Zizers
- 2010         Municipality                 Champtauroz
- 2010         Municipality                       Ueken
- 2010         Municipality                       Bachs
- 2010         Municipality                        Broc
- 2010         Municipality                       Luins
- 2010         Municipality       Saint-Barthélemy (VD)
- 2010         Municipality                   Tartegnin
- 2010         Municipality                    Vernayaz
- 2010         Municipality                      Soazza
- 2010         Municipality                      Masein
- 2010         Municipality                  Herbetswil
- 2010         Municipality                       Arbaz
- 2010         Municipality                     Dänikon
- 2010         Municipality                Bachenbülach
- 2010         Municipality                  Burgistein
- 2010         Municipality                Les Breuleux
- 2010         Municipality                    Vallorbe
- 2010         Municipality                   Courtepin
- 2010         Municipality                 Bad Zurzach
- 2010         Municipality                    Dintikon
- 2010         Municipality             Cheyres-Châbles
- 2010         Municipality                     Minusio
- 2010         Municipality                      Trient
- 2010         Municipality                   Damphreux
- 2010         Municipality                   Aarwangen
- 2010         Municipality                 Niederhasli
- 2010         Municipality             Rickenbach (TG)
- 2010         Municipality                   Zeiningen
- 2010         Municipality                   Maienfeld
- 2010         Municipality                     Alpthal
- 2010         Municipality                     S-chanf
- 2010         Municipality                   Le Mouret
- 2010         Municipality                     Bassins
- 2010         Municipality                    Prangins
- 2010         Municipality          Eppenberg-Wöschnau
- 2010         Municipality                      Epsach
- 2010         Municipality                    Burtigny
- 2010         Municipality                  Seltisberg
- 2010         Municipality                 Füllinsdorf
- 2010         Municipality                      Romoos
- 2010         Municipality                   Niederönz
- 2010         Municipality            Delley-Portalban
- 2010         Municipality                     Bellach
- 2010         Municipality                    Safenwil
- 2010         Municipality                  Zweisimmen
- 2010         Municipality              Berg am Irchel
- 2010         Municipality                       Uzwil
- 2010         Municipality                 Diepflingen
- 2010         Municipality                      Zürich
- 2010         Municipality                    Clarmont
- 2010         Municipality                     Dinhard
- 2010         Municipality                  Bedigliora
- 2010         Municipality                    Lumnezia
- 2010         Municipality                   Merzligen
- 2010         Municipality              Val-de-Travers
- 2010         Municipality                 Grosswangen
- 2010         Municipality                       Gryon
- 2010         Municipality                   Oberkirch
- 2010         Municipality                    Puplinge
- 2010         Municipality                  Fehraltorf
- 2010         Municipality                         Bex
- 2010         Municipality              Ormont-Dessous
- 2010         Municipality                   Cademario
- 2010         Municipality                     Gingins
- 2010         Municipality                Baltschieder
- 2010         Municipality               Stocken-Höfen
- 2010         Municipality                    Egolzwil
- 2010         Municipality                Altdorf (UR)
- 2010         Municipality           Balm bei Günsberg
- 2010         Municipality                      Ursins
- 2010         Municipality                    Aegerten
- 2010         Municipality             Hausen am Albis
- 2010         Municipality                  Geroldswil
- 2010         Municipality                        Trub
- 2010         Municipality       Oulens-sous-Echallens
- 2010         Municipality             Rickenbach (BL)
- 2010         Municipality                     Dornach
- 2010         Municipality                Stetten (SH)
- 2010         Municipality                        Binn
- 2010         Municipality                 Biel-Benken
- 2010         Municipality                     Schänis
- 2010         Municipality      Hergiswil bei Willisau
- 2010         Municipality                   Spiringen
- 2010         Municipality                   Boppelsen
- 2010         Municipality             Niederbuchsiten
- 2010         Municipality                 Courtételle
- 2010         Municipality                   Ried-Brig
- 2010         Municipality                     Rhäzüns
- 2010         Municipality                 Roches (BE)
- 2010         Municipality                       Syens
- 2010         Municipality                 Richterswil
- 2010         Municipality                      Morges
- 2010         Municipality                    Bournens
- 2010         Municipality                    Wil (SG)
- 2010         Municipality                  Auboranges
- 2010         Municipality              Buchholterberg
- 2010         Municipality             Walterswil (BE)
- 2010         Municipality               Breil/Brigels
- 2010         Municipality                   Giebenach
- 2010         Municipality                        Rafz
- 2010         Municipality                    Givisiez
- 2010         Municipality                 Bargen (BE)
- 2010         Municipality                    Schluein
- 2010         Municipality                  Riggisberg
- 2010         Municipality                  Schnottwil
- 2010         Municipality                     Reitnau
- 2010         Municipality              Starrkirch-Wil
- 2010         Municipality                       Olten
- 2010         Municipality           Saint-Martin (VS)
- 2010         Municipality                    Duillier
- 2010         Municipality                       Faido
- 2010         Municipality                     Pleigne
- 2010         Municipality                    Obergoms
- 2010         Municipality                  Bonvillars
- 2010         Municipality                   Lommiswil
- 2010         Municipality                     Giffers
- 2010         Municipality                    Kaufdorf
- 2010         Municipality                 Bargen (SH)
- 2010         Municipality                  Waldenburg
- 2010         Municipality                      Vallon
- 2010         Municipality              Châtillon (JU)
- 2010         Municipality                      Kriens
- 2010         Municipality                  Zollikofen
- 2010         Municipality                Signy-Avenex
- 2010         Municipality                   Ennetmoos
- 2010         Municipality                    Champéry
- 2010         Municipality                 Gossau (ZH)
- 2010         Municipality                     Lyssach
- 2010         Municipality                     Buchegg
- 2010         Municipality                  Ermatingen
- 2010         Municipality                 Steinhausen
- 2010         Municipality                        Höri
- 2010         Municipality              Stein am Rhein
- 2010         Municipality                   Mellingen
- 2010         Municipality                  Bleienbach
- 2010         Municipality                     Evilard
- 2010         Municipality                   Dättlikon
- 2010         Municipality                Lengnau (BE)
- 2010         Municipality                  Bettmeralp
- 2010         Municipality                  Birsfelden
- 2010         Municipality                     Seuzach
- 2010         Municipality                     Sargans
- 2010         Municipality                Othmarsingen
- 2010         Municipality             Arbedo-Castione
- 2010         Municipality                 Reconvilier
- 2010         Municipality                   Loveresse
- 2010         Municipality                     Baulmes
- 2010         Municipality                      Fahrni
- 2010         Municipality                   Cerentino
- 2010         Municipality                   Stammheim
- 2010         Municipality                  Renan (BE)
- 2010         Municipality                      Toffen
- 2010         Municipality                  Ochlenberg
- 2010         Municipality                  Pontresina
- 2010         Municipality                     Noville
- 2010         Municipality                   Muri (AG)
- 2010         Municipality                      Perroy
- 2010         Municipality                 Häfelfingen
- 2010         Municipality        Chavannes-sur-Moudon
- 2010         Municipality                  Murgenthal
- 2010         Municipality         Belmont-sur-Yverdon
- 2010         Municipality         Langnau im Emmental
- 2010         Municipality                   Bardonnex
- 2010         Municipality                        Birr
- 2010         Municipality                Sainte-Croix
- 2010         Municipality                      Abtwil
- 2010         Municipality                   Neunkirch
- 2010         Municipality                 Kreuzlingen
- 2010         Municipality                     Ittigen
- 2010         Municipality                     Sorengo
- 2010         Municipality      Bütschwil-Ganterschwil
- 2010         Municipality                      Dozwil
- 2010         Municipality                     Evolène
- 2010         Municipality            Birmensdorf (ZH)
- 2010         Municipality        Nuglar-St. Pantaleon
- 2010         Municipality                        Baar
- 2010         Municipality             Zillis-Reischen
- 2010         Municipality                    Habsburg
- 2010         Municipality                      Stabio
- 2010         Municipality                   Büsserach
- 2010         Municipality                      Wartau
- 2010         Municipality                  Arboldswil
- 2010         Municipality                      Trélex
- 2010         Municipality                     Chessel
- 2010         Municipality             Rapperswil-Jona
- 2010         Municipality                       Nidau
- 2010         Municipality                 Haute-Sorne
- 2010         Municipality                 Rossemaison
- 2010         Municipality            Bussy-sur-Moudon
- 2010         Municipality                 Vaz/Obervaz
- 2010         Municipality                  Bonstetten
- 2010         Municipality              Unterlangenegg
- 2010         Municipality                    Neuenhof
- 2010         Municipality                     Mesocco
- 2010         Municipality                     Uitikon
- 2010         Municipality            Grosshöchstetten
- 2010         Municipality                      Uttwil
- 2010         Municipality                     Vernier
- 2010         Municipality                    Schelten
- 2010         Municipality               Mézières (FR)
- 2010         Municipality                   Ferreyres
- 2010         Municipality                  Hubersdorf
- 2010         Municipality             Rickenbach (SO)
- 2010         Municipality              Vully-les-Lacs
- 2010         Municipality                   Arlesheim
- 2010         Municipality                     Riniken
- 2010         Municipality                       Elsau
- 2010         Municipality                   Stettfurt
- 2010         Municipality                     Rubigen
- 2010         Municipality                     Flerden
- 2010         Municipality                Hildisrieden
- 2010         Municipality                   Brüttelen
- 2010         Municipality                    Hersberg
- 2010         Municipality          Chavannes-des-Bois
- 2010         Municipality                       Lancy
- 2010         Municipality                     Thurnen
- 2010         Municipality                Oberrohrdorf
- 2010         Municipality                        Zuoz
- 2010         Municipality                 Kaiseraugst
- 2010         Municipality                   Ferpicloz
- 2010         Municipality                    Günsberg
- 2010         Municipality                   La Sonnaz
- 2010         Municipality               Leimbach (AG)
- 2010         Municipality                   Rüderswil
- 2010         Municipality                         Auw
- 2010         Municipality                         Zug
- 2010         Municipality               Pont-la-Ville
- 2010         Municipality                        Jens
- 2010         Municipality                     Eriswil
- 2010         Municipality               Sant'Antonino
- 2010         Municipality                      Altnau
- 2010         Municipality                     Muralto
- 2010         Municipality                   Zell (LU)
- 2010         Municipality                 Rheinfelden
- 2010         Municipality                   Lignières
- 2010         Municipality                   Gerzensee
- 2010         Municipality                    Pfaffnau
- 2010         Municipality                       Jonen
- 2010         Municipality                 Brienzwiler
- 2010         Municipality                    Bösingen
- 2010         Municipality                    Menziken
- 2010         Municipality                     Sirnach
- 2010         Municipality           Yverdon-les-Bains
- 2010         Municipality             Teufenthal (AG)
- 2010         Municipality                       Gland
- 2010         Municipality             Amlikon-Bissegg
- 2010         Municipality                      Bedano
- 2010         Municipality                     Dürnten
- 2010         Municipality                 Benken (ZH)
- 2010         Municipality                  Heitenried
- 2010         Municipality                   Ingenbohl
- 2010         Municipality                 Büttenhardt
- 2010         Municipality                       Bauma
- 2010         Municipality                       Inden
- 2010         Municipality                   Rüdlingen
- 2010         Municipality                      Melide
- 2010         Municipality                    Meikirch
- 2010         Municipality                    Klingnau
- 2010         Municipality                    Ettingen
- 2010         Municipality                    Gampelen
- 2010         Municipality      Essertines-sur-Yverdon
- 2010         Municipality                 Mettauertal
- 2010         Municipality                      Liddes
- 2010         Municipality                  Wenslingen
- 2010         Municipality                     Concise
- 2010         Municipality                Lengnau (AG)
- 2010         Municipality                      Wimmis
- 2010         Municipality                 Kandergrund
- 2010         Municipality                   Eschlikon
- 2010         Municipality                   Hitzkirch
- 2010         Municipality                    Daillens
- 2010         Municipality                Affeltrangen
- 2010         Municipality                    Thörigen
- 2010         Municipality                       Porza
- 2010         Municipality                  Perrefitte
- 2010         Municipality                       Ogens
- 2010         Municipality                  Otelfingen
- 2010         Municipality                 Fieschertal
- 2010         Municipality                      Arogno
- 2010         Municipality              Niederweningen
- 2010         Municipality             Collombey-Muraz
- 2010         Municipality                 Breitenbach
- 2010         Municipality                    Plasselb
- 2010         Municipality                        Gais
- 2010         Municipality                 Renens (VD)
- 2010         Municipality                Bätterkinden
- 2010         Municipality                 Vandoeuvres
- 2010         Municipality                      Cronay
- 2010         Municipality                     Locarno
- 2010         Municipality                 Steinerberg
- 2010         Municipality                      Jenins
- 2010         Municipality                     Vaulruz
- 2010         Municipality                   Wyssachen
- 2010         Municipality                   Entlebuch
- 2010         Municipality                    Kienberg
- 2010         Municipality                   Le Chenit
- 2010         Municipality                Schönengrund
- 2010         Municipality                 Fraubrunnen
- 2010         Municipality                    Biberist
- 2010         Municipality                    Martigny
- 2010         Municipality                  Kernenried
- 2010         Municipality                    Saas-Fee
- 2010         Municipality                      Blauen
- 2010         Municipality                     Däniken
- 2010         Municipality                   Andermatt
- 2010         Municipality                   Champagne
- 2010         Municipality                    Bedretto
- 2010         Municipality                    Zeneggen
- 2010         Municipality                       Rossa
- 2010         Municipality                        Maur
- 2010         Municipality                 Niederbüren
- 2010         Municipality                      Coeuve
- 2010         Municipality                     Fétigny
- 2010         Municipality            Heiligenschwendi
- 2010         Municipality                       Ardon
- 2010         Municipality               Saint-Maurice
- 2010         Municipality                  Moosleerau
- 2010         Municipality                        Nyon
- 2010         Municipality                     Koblenz
- 2010         Municipality                      Iffwil
- 2010         Municipality                    Kehrsatz
- 2010         Municipality                      Villaz
- 2010         Municipality               Oberwil-Lieli
- 2010         Municipality            Wünnewil-Flamatt
- 2010         Municipality                 Studen (BE)
- 2010         Municipality                Marbach (SG)
- 2010         Municipality                      Flaach
- 2010         Municipality                    Cureglia
- 2010         Municipality          Freienstein-Teufen
- 2010         Municipality                     Chénens
- 2010         Municipality                Schwellbrunn
- 2010         Municipality                       Bulle
- 2010         Municipality                  Serravalle
- 2010         Municipality                  Därstetten
- 2010         Municipality                     Aarburg
- 2010         Municipality                  Siglistorf
- 2010         Municipality          Romanel-sur-Morges
- 2010         Municipality                     Selzach
- 2010         Municipality                  La Baroche
- 2010         Municipality                   Binningen
- 2010         Municipality                  Oberrieden
- 2010         Municipality                     Chippis
- 2010         Municipality                     Riviera
- 2010         Municipality                       Cazis
- 2010         Municipality                  Hüntwangen
- 2010         Municipality                      Oppens
- 2010         Municipality                 Le Landeron
- 2010         Municipality             Brusino Arsizio
- 2010         Municipality                   Zeglingen
- 2010         Municipality                   Auenstein
- 2010         Municipality                   Bad Ragaz
- 2010         Municipality                 Thierachern
- 2010         Municipality                      Gempen
- 2010         Municipality          Bourg-Saint-Pierre
- 2010         Municipality                     Grancia
- 2010         Municipality                   Soyhières
- 2010         Municipality           Le Grand-Saconnex
- 2010         Municipality                    Dardagny
- 2010         Municipality               Perly-Certoux
- 2010         Municipality                  Val-de-Ruz
- 2010         Municipality                     Bannwil
- 2010         Municipality                      Coppet
- 2010         Municipality                     Trimmis
- 2010         Municipality               Mont-la-Ville
- 2010         Municipality                 Steffisburg
- 2010         Municipality           La Chaux-de-Fonds
- 2010         Municipality                     Silenen
- 2010         Municipality                       Turgi
- 2010         Municipality                    Triengen
- 2010         Municipality                     Eschert
- 2010         Municipality                     Gordola
- 2010         Municipality                      Buochs
- 2010         Municipality                      Boswil
- 2010         Municipality                     Huttwil
- 2010         Municipality                     Leutwil
- 2010         Municipality              Arnex-sur-Orbe
- 2010         Municipality                 Känerkinden
- 2010         Municipality                  Hirschthal
- 2010         Municipality                 St. Stephan
- 2010         Municipality                 Benken (SG)
- 2010         Municipality           Turtmann-Unterems
- 2010         Municipality                  Lutzenberg
- 2010         Municipality                      Ruswil
- 2010         Municipality                    Kallnach
- 2010         Municipality                    Brittnau
- 2010         Municipality                     Eglisau
- 2010         Municipality               Rothenbrunnen
- 2010         Municipality                        Trey
- 2010         Municipality              Frauenkappelen
- 2010         Municipality                    Vuarrens
- 2010         Municipality                      Riddes
- 2010         Municipality                      Orzens
- 2010         Municipality                   Dübendorf
- 2010         Municipality                     Wynigen
- 2010         Municipality                 Ehrendingen
- 2010         Municipality                Waltenschwil
- 2010         Municipality                Gelterkinden
- 2010         Municipality                   Appenzell
- 2010         Municipality                      Zernez
- 2010         Municipality                  La Brévine
- 2010         Municipality                Ependes (VD)
- 2010         Municipality                       Raron
- 2010         Municipality           Villars-sous-Yens
- 2010         Municipality                      Tuggen
- 2010         Municipality                       Köniz
- 2010         Municipality                     Pfäfers
- 2010         Municipality                Schneisingen
- 2010         Municipality                    Mex (VD)
- 2010         Municipality      Oberhofen am Thunersee
- 2010         Municipality                  Nenzlingen
- 2010         Municipality                     Farnern
- 2010         Municipality            Chapelle (Glâne)
- 2010         Municipality                 Schlierbach
- 2010         Municipality                 Mattstetten
- 2010         Municipality                        Seon
- 2010         Municipality                   Mörschwil
- 2010         Municipality             Obergerlafingen
- 2010         Municipality                Kirchlindach
- 2010         Municipality                    Avenches
- 2010         Municipality                   Hünenberg
- 2010         Municipality                      Thusis
- 2010         Municipality                     Quarten
- 2010         Municipality                      Moudon
- 2010         Municipality   Vuisternens-devant-Romont
- 2010         Municipality                      Lauerz
- 2010         Municipality                       Saxon
- 2010         Municipality                    Wallbach
- 2010         Municipality                     Givrins
- 2010         Municipality                       Uster
- 2010         Municipality                Wasterkingen
- 2010         Municipality                      Giswil
- 2010         Municipality                      Lucens
- 2010         Municipality                     Ufhusen
- 2010         Municipality                      Nendaz
- 2010         Municipality                 Gerlafingen
- 2010         Municipality                 Val Müstair
- 2010         Municipality                        Eriz
- 2010         Municipality                   Capriasca
- 2010         Municipality              Visperterminen
- 2010         Municipality                     Thalwil
- 2010         Municipality           Prato (Leventina)
- 2010         Municipality                     Troinex
- 2010         Municipality               Ostermundigen
- 2010         Municipality                         Ins
- 2010         Municipality       Matten bei Interlaken
- 2010         Municipality                    Sennwald
- 2010         Municipality                     Seeberg
- 2010         Municipality                   Jonschwil
- 2010         Municipality                 Lajoux (JU)
- 2010         Municipality                    Corseaux
- 2010         Municipality      Santa Maria in Calanca
- 2010         Municipality        Brione sopra Minusio
- 2010         Municipality                      Lugnez
- 2010         Municipality            Les Genevez (JU)
- 2010         Municipality                    Bussnang
- 2010         Municipality                     Gurmels
- 2010         Municipality                    Delémont
- 2010         Municipality                      Worben
- 2010         Municipality                      Luzern
- 2010         Municipality                      Volken
- 2010         Municipality                   Hasliberg
- 2010         Municipality                  Tolochenaz
- 2010         Municipality                    Zollikon
- 2010         Municipality                     Altikon
- 2010         Municipality                  Rothenfluh
- 2010         Municipality                  Wolfhalden
- 2010         Municipality         Diessbach bei Büren
- 2010         Municipality                     Steinen
- 2010         Municipality                  Tschappina
- 2010         Municipality                      Founex
- 2010         Municipality                  Hochfelden
- 2010         Municipality              Corcelles (BE)
- 2010         Municipality                     Belfaux
- 2010         Municipality           Romainmôtier-Envy
- 2010         Municipality                    Develier
- 2010         Municipality             Möriken-Wildegg
- 2010         Municipality        Metzerlen-Mariastein
- 2010         Municipality             Bourg-en-Lavaux
- 2010         Municipality                     Winznau
- 2010         Municipality                   Courgenay
- 2010         Municipality                    Wildberg
- 2010         Municipality                  Acquarossa
- 2010         Municipality                   Rougemont
- 2010         Municipality                  Freienbach
- 2010         Municipality                   Schupfart
- 2010         Municipality                Hunzenschwil
- 2010         Municipality                    Dägerlen
- 2010         Municipality                        Orny
- 2010         Municipality                      Tübach
- 2010         Municipality                     Démoret
- 2010         Municipality                   Corbières
- 2010         Municipality                    Lovatens
- 2010         Municipality                        Horn
- 2010         Municipality            Forst-Längenbühl
- 2010         Municipality               Oberdorf (SO)
- 2010         Municipality                      Avully
- 2010         Municipality              Grossaffoltern
- 2010         Municipality                       Stäfa
- 2010         Municipality                    Balsthal
- 2010         Municipality                  Courgevaux
- 2010         Municipality                   Gondiswil
- 2010         Municipality                Seedorf (UR)
- 2010         Municipality     Zihlschlacht-Sitterdorf
- 2010         Municipality                      Weiach
- 2010         Municipality             Uesslingen-Buch
- 2010         Municipality                        Bühl
- 2010         Municipality                      Quinto
- 2010         Municipality                        Suhr
- 2010         Municipality                        Riaz
- 2010         Municipality                  Killwangen
- 2010         Municipality                  Lully (VD)
- 2010         Municipality                   Coldrerio
- 2010         Municipality                    Geuensee
- 2010         Municipality               Oberentfelden
- 2010         Municipality           Felben-Wellhausen
- 2010         Municipality                     Gollion
- 2010         Municipality        Valeyres-sous-Ursins
- 2010         Municipality                     Tecknau
- 2010         Municipality                      Wassen
- 2010         Municipality               Gündlischwand
- 2010         Municipality                      Cuarny
- 2010         Municipality             Plan-les-Ouates
- 2010         Municipality                      Ligerz
- 2010         Municipality                   Lupsingen
- 2010         Municipality                  Porrentruy
- 2010         Municipality                 Zuzwil (BE)
- 2010         Municipality                      Rovray
- 2010         Municipality                   Täuffelen
- 2010         Municipality            Oberhelfenschwil
- 2010         Municipality                   Böttstein
- 2010         Municipality     Oberried am Brienzersee
- 2010         Municipality                     Lostorf
- 2010         Municipality                  Lavertezzo
- 2010         Municipality              Rüti bei Büren
- 2010         Municipality                     Eggiwil
- 2010         Municipality                 Staffelbach
- 2010         Municipality                      Sagogn
- 2010         Municipality     Basadingen-Schlattingen
- 2010         Municipality                      Lauwil
- 2010         Municipality           Illnau-Effretikon
- 2010         Municipality               Schwarzenburg
- 2010         Municipality                 Schwadernau
- 2010         Municipality                    Tujetsch
- 2010         Municipality                Meierskappel
- 2010         Municipality                 Beurnevésin
- 2010         Municipality                Oberweningen
- 2010         Municipality                     Muttenz
- 2010         Municipality                  Beatenberg
- 2010         Municipality                   Wald (ZH)
- 2010         Municipality                 Wohlen (AG)
- 2010         Municipality                    La Rippe
- 2010         Municipality                Freimettigen
- 2010         Municipality                   Gränichen
- 2010         Municipality                     Lotzwil
- 2010         Municipality                   Veysonnaz
- 2010         Municipality                      Flühli
- 2010         Municipality                   Allschwil
- 2010         Municipality              Schmitten (FR)
- 2010         Municipality                    Madiswil
- 2010         Municipality                       Rivaz
- 2010         Municipality                   Neuendorf
- 2010         Municipality                    Ossingen
- 2010         Municipality                   Oberglatt
- 2010         Municipality               Wetzikon (ZH)
- 2010         Municipality                  Regensdorf
- 2010         Municipality                  Kandersteg
- 2010         Municipality                    Novaggio
- 2010         Municipality              St. Margrethen
- 2010         Municipality                  Bellinzona
- 2010         Municipality                    Subingen
- 2010         Municipality                    Leuggern
- 2010         Municipality                   Wald (AR)
- 2010         Municipality Deisswil bei Münchenbuchsee
- 2010         Municipality                 Sarmenstorf
- 2010         Municipality                    Endingen
- 2010         Municipality                   Wädenswil
- 2010         Municipality                     Buttwil
- 2010         Municipality              Kirchberg (BE)
- 2010         Municipality               Kleinbösingen
- 2010         Municipality                   Steinmaur
- 2010         Municipality            Meisterschwanden
- 2010         Municipality                    Hochdorf
- 2010         Municipality                     Oberegg
- 2010         Municipality                Treycovagnes
- 2010         Municipality                Morrens (VD)
- 2010         Municipality                  Ausserberg
- 2010         Municipality                     Nuvilly
- 2010         Municipality              Aedermannsdorf
- 2010         Municipality          Hasle bei Burgdorf
- 2010         Municipality                  Rütschelen
- 2010         Municipality               Hombrechtikon
- 2010         Municipality                   Botterens
- 2010         Municipality          Ronco sopra Ascona
- 2010         Municipality                     Brütten
- 2010         Municipality                      Tamins
- 2010         Municipality             Vaux-sur-Morges
- 2010         Municipality                      Mathod
- 2010         Municipality                      Glarus
- 2010         Municipality                   Grüningen
- 2010         Municipality                       Inwil
- 2010         Municipality                Saint-Cergue
- 2010         Municipality                     Alpnach
- 2010         Municipality               Ecublens (FR)
- 2010         Municipality                  Untereggen
- 2010         Municipality                Le Châtelard
- 2010         Municipality       Hofstetten bei Brienz
- 2010         Municipality                   Alberswil
- 2010         Municipality                Merenschwand
- 2010         Municipality                   Marchissy
- 2010         Municipality                 Bottighofen
- 2010         Municipality                    Klosters
- 2010         Municipality                       Wängi
- 2010         Municipality               Bougy-Villars
- 2010         Municipality                      Maggia
- 2010         Municipality                  Aesch (ZH)
- 2010         Municipality                  Obergösgen
- 2010         Municipality                   Uetendorf
- 2010         Municipality                    Bretzwil
- 2010         Municipality                    Bolligen
- 2010         Municipality             Villeneuve (VD)
- 2010         Municipality                    Dottikon
- 2010         Municipality                   Wald (BE)
- 2010         Municipality                      Bolken
- 2010         Municipality              Martigny-Combe
- 2010         Municipality                       Féchy
- 2010         Municipality                        Arth
- 2010         Municipality                        Orbe
- 2010         Municipality                     Oberhof
- 2010         Municipality                       Avers
- 2010         Municipality                     Ballens
- 2010         Municipality              Mezzovico-Vira
- 2010         Municipality                    Salmsach
- 2010         Municipality                   Lohn (SH)
- 2010         Municipality       Cheseaux-sur-Lausanne
- 2010         Municipality               Montpreveyres
- 2010         Municipality                    Rothrist
- 2010         Municipality                    Provence
- 2010         Municipality                   Grimisuat
- 2010         Municipality                  Ennetbaden
- 2010         Municipality        Oetwil an der Limmat
- 2010         Municipality                 Höchstetten
- 2010         Municipality                   Oberuzwil
- 2010         Municipality                    Müllheim
- 2010         Municipality                   Cugy (FR)
- 2010         Municipality                      Gurbrü
- 2010         Municipality                   Birwinken
- 2010         Municipality                    Wuppenau
- 2010         Municipality           Schönholzerswilen
- 2010         Municipality                    Heimberg
- 2010         Municipality                 Oeschenbach
- 2010         Municipality                        Fiez
- 2010         Municipality                   Titterten
- 2010         Municipality             Cheseaux-Noréaz
- 2010         Municipality                     Vionnaz
- 2010         Municipality                 Haute-Ajoie
- 2010         Municipality                   Münsingen
- 2010         Municipality                    Villeret
- 2010         Municipality                    Cudrefin
- 2010         Municipality                   Fischbach
- 2010         Municipality                Allmendingen
- 2010         Municipality                  Besenbüren
- 2010         Municipality                Zwischbergen
- 2010         Municipality                Reinach (AG)
- 2010         Municipality                   Steckborn
- 2010         Municipality                Trachselwald
- 2010         Municipality                      Ziefen
- 2010         Municipality                 Liedertswil
- 2010         Municipality                     Autigny
- 2010         Municipality                     Safnern
- 2010         Municipality                  Romanshorn
- 2010         Municipality                      Assens
- 2010         Municipality                     Herisau
- 2010         Municipality                    Maroggia
- 2010         Municipality                     Neerach
- 2010         Municipality                     Sisseln
- 2010         Municipality                     Hüniken
- 2010         Municipality                   Kemmental
- 2010         Municipality                     Geltwil
- 2010         Municipality                   Surpierre
- 2010         Municipality                    Untervaz
- 2010         Municipality          Chavannes-de-Bogis
- 2010         Municipality                Müntschemier
- 2010         Municipality                  Volketswil
- 2010         Municipality                       Marly
- 2010         Municipality           La Grande Béroche
- 2010         Municipality                     Conthey
- 2010         Municipality             Rickenbach (LU)
- 2010         Municipality                    Oberbalm
- 2010         Municipality              Langrickenbach
- 2010         Municipality                     Marsens
- 2010         Municipality                      Kloten
- 2010         Municipality                Brot-Plamboz
- 2010         Municipality                   Diemtigen
- 2010         Municipality                Saignelégier
- 2010         Municipality             Pregny-Chambésy
- 2010         Municipality                      Linden
- 2010         Municipality                   Landiswil
- 2010         Municipality                     Kallern
- 2010         Municipality                     Treiten
- 2010         Municipality              Mettmenstetten
- 2010         Municipality                   Rümlingen
- 2010         Municipality                  Walkringen
- 2010         Municipality                  Laufenburg
- 2010         Municipality             Disentis/Mustér
- 2010         Municipality               Les Verrières
- 2010         Municipality                     Bettwil
- 2010         Municipality                        Port
- 2010         Municipality                        Alle
- 2010         Municipality                Beinwil (SO)
- 2010         Municipality                     Premier
- 2010         Municipality                      Fläsch
- 2010         Municipality                    Neunforn
- 2010         Municipality                        Eich
- 2010         Municipality                        Visp
- 2010         Municipality                     Opfikon
- 2010         Municipality            Wiler (Lötschen)
- 2010         Municipality                   Oberbüren
- 2010         Municipality                 Aeschi (SO)
- 2010         Municipality                     Saubraz
- 2010         Municipality                   Löhningen
- 2010         Municipality                       Brugg
- 2010         Municipality                   Baldingen
- 2010         Municipality                      Ferden
- 2010         Municipality                      Weesen
- 2010         Municipality                    Gurzelen
- 2010         Municipality              Kilchberg (BL)
- 2010         Municipality                       Arosa
- 2010         Municipality                    Oberburg
- 2010         Municipality                      Ipsach
- 2010         Municipality                     Lengwil
- 2010         Municipality         Vufflens-le-Château
- 2010         Municipality                  Unteriberg
- 2010         Municipality                 Frenkendorf
- 2010         Municipality                Bogis-Bossey
- 2010         Municipality                   Unterbäch
- 2010         Municipality                  Egerkingen
- 2010         Municipality               Tenero-Contra
- 2010         Municipality                   Engelberg
- 2010         Municipality                Roggwil (BE)
- 2010         Municipality                     Bottens
- 2010         Municipality                     Mirchel
- 2010         Municipality                   Bregaglia
- 2010         Municipality                  Glarus Süd
- 2010         Municipality           Sonceboz-Sombeval
- 2010         Municipality                     Embrach
- 2010         Municipality                     Neuheim
- 2010         Municipality                       Greng
- 2010         Municipality                    Schüpfen
- 2010         Municipality                   Schangnau
- 2010         Municipality                       Aigle
- 2010         Municipality                    Obfelden
- 2010         Municipality                    Birrhard
- 2010         Municipality             Ponte Capriasca
- 2010         Municipality                    Goumoëns
- 2010         Municipality                  St. Moritz
- 2010         Municipality                  Montricher
- 2010         Municipality                 Onnens (VD)
- 2010         Municipality                     Bubikon
- 2010         Municipality                   Deitingen
- 2010         Municipality               Lavey-Morcles
- 2010         Municipality                Rottenschwil
- 2010         Municipality                  Schinznach
- 2010         Municipality                       Cevio
- 2010         Municipality                 Teufen (AR)
- 2010         Municipality                  Unterägeri
- 2010         Municipality                      Aclens
- 2010         Municipality                     Vitznau
- 2010         Municipality                  Schüpfheim
- 2010         Municipality                  Cortaillod
- 2010         Municipality                      Küblis
- 2010         Municipality                      Graben
- 2010         Municipality                    Attiswil
- 2010         Municipality                 Schlossrued
- 2010         Municipality                      Bitsch
- 2010         Municipality                     Böbikon
- 2010         Municipality                 Glarus Nord
- 2010         Municipality                  Massonnens
- 2010         Municipality                        Chur
- 2010         Municipality                Wohlenschwil
- 2010         Municipality                      Aranno
- 2010         Municipality                  Wangenried
- 2010         Municipality          Fischbach-Göslikon
- 2010         Municipality                    Rüfenach
- 2010         Municipality                    Cormoret
- 2010         Municipality                      Biasca
- 2010         Municipality                   Neuchâtel
- 2010         Municipality                        Lens
- 2010         Municipality                   Mendrisio
- 2010         Municipality                       Tresa
- 2010         Municipality              Hauterive (FR)
- 2010         Municipality             Holderbank (SO)
- 2010         Municipality                Schlatt (ZH)
- 2010         Municipality                       Wikon
- 2010         Municipality                       Risch
- 2010         Municipality                    Bofflens
- 2010         Municipality                     Sullens
- 2010         Municipality                    Dietikon
- 2010         Municipality                    Bellikon
- 2010         Municipality                  Mont-Noble
- 2010         Municipality                       Manno
- 2010         Municipality               Chêne-Pâquier
- 2010         Municipality        Thalheim an der Thur
- 2010         Municipality                  Utzenstorf
- 2010         Municipality                   Castaneda
- 2010         Municipality                     Ergisch
- 2010         Municipality                     Nesslau
- 2010         Municipality                   Ferenbalm
- 2010         Municipality                     Hagneck
- 2010         Municipality                     Schiers
- 2010         Municipality               Oetwil am See
- 2010         Municipality                Saint-Livres
- 2010         Municipality                 La Verrerie
- 2010         Municipality                    Crassier
- 2010         Municipality                    Windisch
- 2010         Municipality                 Schönenwerd
- 2010         Municipality                     Choulex
- 2010         Municipality                 Staldenried
- 2010         Municipality                     Au (SG)
- 2010         Municipality               Cressier (FR)
- 2010         Municipality                  Hasle (LU)
- 2010         Municipality        Tschiertschen-Praden
- 2010         Municipality                      Murten
- 2010         Municipality                     Greppen
- 2010         Municipality                 Ramlinsburg
- 2010         Municipality                  Buchs (SG)
- 2010         Municipality                      Meggen
- 2010         Municipality                 Glattfelden
- 2010         Municipality                   Krattigen
- 2010         Municipality              Saint-Gingolph
- 2010         Municipality                  Diepoldsau
- 2010         Municipality                 Saint-Brais
- 2010         Municipality                        Gals
- 2010         Municipality                   Zielebach
- 2010         Municipality          Affoltern am Albis
- 2010         Municipality                  Wilderswil
- 2010         Municipality                   Cadenazzo
- 2010         Municipality                     Morcote
- 2010         Municipality                   Kaltbrunn
- 2010         Municipality     Saint-Légier-La Chiésaz
- 2010         Municipality                 Bassersdorf
- 2010         Municipality           Oberwil bei Büren
- 2010         Municipality                  Tägerwilen
- 2010         Municipality                 Hautemorges
- 2010         Municipality                  Brünisried
- 2010         Municipality                      Melano
- 2010         Municipality                  Weinfelden
- 2010         Municipality                   Unterkulm
- 2010         Municipality            Kleinandelfingen
- 2010         Municipality                     Tschugg
- 2010         Municipality                   Sorvilier
- 2010         Municipality                       Enges
- 2010         Municipality                    Altbüron
- 2010         Municipality                       Muhen
- 2010         Municipality                       Ayent
- 2010         Municipality                    Canobbio
- 2010         Municipality               Collina d'Oro
- 2010         Municipality                 Langenbruck
- 2010         Municipality                 Port-Valais
- 2010         Municipality                  Bettwiesen
- 2010         Municipality                   Corgémont
- 2010         Municipality                   Cugy (VD)
- 2010         Municipality                  Schöftland
- 2010         Municipality                 Grindelwald
- 2010         Municipality                      Lumino
- 2010         Municipality    Walliswil bei Niederbipp
- 2010         Municipality                 Ilanz/Glion
- 2010         Municipality                    Eclépens
- 2010         Municipality               Oberdiessbach
- 2010         Municipality              Obersiggenthal
- 2010         Municipality              Sutz-Lattrigen
- 2010         Municipality                 Neyruz (FR)
- 2010         Municipality                    Küttigen
- 2010         Municipality                  Centovalli
- 2010         Municipality                  Lignerolle
- 2010         Municipality                    Oberbipp
- 2010         Municipality                    Melchnau
- 2010         Municipality                        Embd
- 2010         Municipality                        Thun
- 2010         Municipality                  Schmerikon
- 2010         Municipality                    Bettlach
- 2010         Municipality                  Wislikofen
- 2010         Municipality                      Biglen
- 2010         Municipality                     Thürnen
- 2010         Municipality                  Bottmingen
- 2010         Municipality                  Etagnières
- 2010         Municipality                     Vernate
- 2010         Municipality                     Sempach
- 2010         Municipality                      Comano
- 2010         Municipality                      Orpund
- 2010         Municipality                  Bossonnens
- 2010         Municipality                    Saicourt
- 2010         Municipality                 Reigoldswil
- 2010         Municipality               Belmont-Broye
- 2010         Municipality                   Les Clées
- 2010         Municipality                       Davos
- 2010         Municipality                  La Brillaz
- 2010         Municipality                    Verzasca
- 2010         Municipality               Oberlunkhofen
- 2010         Municipality                      Yvorne
- 2010         Municipality                  Roche (VD)
- 2010         Municipality                      Sufers
- 2010         Municipality                       Furna
- 2010         Municipality                     Albinen
- 2010         Municipality                 Beromünster
- 2010         Municipality                   Gravesano
- 2010         Municipality                     Seengen
- 2010         Municipality                  Penthéréaz
- 2010         Municipality                  Wilchingen
- 2010         Municipality                    Laconnex
- 2010         Municipality                    Dulliken
- 2010         Municipality                     Therwil
- 2010         Municipality              Weiningen (ZH)
- 2010         Municipality                       Jussy
- 2010         Municipality                 Kleinlützel
- 2010         Municipality                      Blonay
- 2010         Municipality                Bettenhausen
- 2010         Municipality                   Islisberg
- 2010         Municipality                   Häutligen
- 2010         Municipality                        Worb
- 2010         Municipality                    Commugny
- 2010         Municipality                   Buchillon
- 2010         Municipality                   Riederalp
- 2010         Municipality      Lüsslingen-Nennigkofen
- 2010         Municipality                    Essertes
- 2010         Municipality                     Caslano
- 2010         Municipality               Rekingen (AG)
- 2010         Municipality                  Hefenhofen
- 2010         Municipality                  Altishofen
- 2010         Municipality                      Malans
- 2010         Municipality                   Collonges
- 2010         Municipality                   Confignon
- 2010         Municipality                   Arni (BE)
- 2010         Municipality                     Puidoux
- 2010         Municipality                      Meilen
- 2010         Municipality                       Isone
- 2010         Municipality     Feldbrunnen-St. Niklaus
- 2010         Municipality                     Zullwil
- 2010         Municipality                     Biezwil
- 2010         Municipality                      Seehof
- 2010         Municipality                      Brusio
- 2010         Municipality                Bois-d'Amont
- 2010         Municipality                   Dietlikon
- 2010         Municipality                Walzenhausen
- 2010         Municipality                     Maracon
- 2010         Municipality                   Bremblens
- 2010         Municipality                     Olsberg
- 2010         Municipality                 Montcherand
- 2010         Municipality                  Vuiteboeuf
- 2010         Municipality             Eschenbach (SG)
- 2010         Municipality                  Crans (VD)
- 2010         Municipality                  Reute (AR)
- 2010         Municipality                   Remaufens
- 2010         Municipality                 Reichenburg
- 2010         Municipality                   Rossenges
- 2010         Municipality                    Wiliberg
- 2010         Municipality         Bremgarten bei Bern
- 2010         Municipality                      Cornol
- 2010         Municipality                       Grabs
- 2010         Municipality                 Tegerfelden
- 2010         Municipality                     Knutwil
- 2010         Municipality                      Messen
- 2010         Municipality              Bergün Filisur
- 2010         Municipality                      Schötz
- 2010         Municipality                    Dierikon
- 2010         Municipality                      Wahlen
- 2010         Municipality                        Thal
- 2010         Municipality                     Balgach
- 2010         Municipality            Wangen bei Olten
- 2010         Municipality             Rickenbach (ZH)
- 2010         Municipality                  Montilliez
- 2010         Municipality                       Wäldi
- 2010         Municipality                     Liestal
- 2010         Municipality                Bürglen (UR)
- 2010         Municipality                    Orsières
- 2010         Municipality                  Lully (FR)
- 2010         Municipality                        Cham
- 2010         Municipality              Niederrohrdorf
- 2010         Municipality                     Satigny
- 2010         Municipality                   Rumisberg
- 2010         Municipality                   Oftringen
- 2010         Municipality                 Schleitheim
- 2010         Municipality                   Fräschels
- 2010         Municipality                        Oron
- 2010         Municipality                Attinghausen
- 2010         Municipality                    Kölliken
- 2010         Municipality                     Nusshof
- 2010         Municipality                      Galmiz
- 2010         Municipality                      Egnach
- 2010         Municipality                   Mühleberg
- 2010         Municipality                      Mutrux
- 2010         Municipality                     Zunzgen
- 2010         Municipality                 Brenzikofen
- 2010         Municipality                  Kestenholz
- 2010         Municipality                     Zufikon
- 2010         Municipality                   Sonvilier
- 2010         Municipality                     Sissach
- 2010         Municipality                     Zumikon
- 2010         Municipality                     Meinier
- 2010         Municipality                  Rodersdorf
- 2010         Municipality                     Hundwil
- 2010         Municipality               Château-d'Oex
- 2010         Municipality         Villarsel-sur-Marly
- 2010         Municipality                  Niederdorf
- 2010         Municipality                     Bercher
- 2010         Municipality                      Auswil
- 2010         Municipality                   Muotathal
- 2010         Municipality                Schwaderloch
- 2010         Municipality                    Ermensee
- 2010         Municipality                     Ballwil
- 2010         Municipality                Läufelfingen
- 2010         Municipality                    Molondin
- 2010         Municipality       Lüterkofen-Ichertswil
- 2010         Municipality                    Beringen
- 2010         Municipality        Wiler bei Utzenstorf
- 2010         Municipality                     Veytaux
- 2010         Municipality                   Grandcour
- 2010         Municipality              Rohrbachgraben
- 2010         Municipality                     Dietwil
- 2010         Municipality             Untersiggenthal
- 2010         Municipality                   Wettingen
- 2010         Municipality                     Buckten
- 2010         Municipality                   Zell (ZH)
- 2010         Municipality                 Andwil (SG)
- 2010         Municipality                Wiesendangen
- 2010         Municipality                   Rehetobel
- 2010         Municipality                   Solothurn
- 2010         Municipality             Les Planchettes
- 2010         Municipality                 Wagenhausen
- 2010         Municipality                      Matran
- 2010         Municipality             Alto Malcantone
- 2010         Municipality               La Neuveville
- 2010         Municipality                     Berolle
- 2010         Municipality                   Nunningen
- 2010         Municipality               Niedergesteln
- 2010         Municipality             Münchwilen (AG)
- 2010         Municipality                      Ascona
- 2010         Municipality                  Recherswil
- 2010         Municipality                  Gurtnellen
- 2010         Municipality                     Simplon
- 2010         Municipality                    Villigen
- 2010         Municipality                  Churwalden
- 2010         Municipality                 Konolfingen
- 2010         Municipality                Dagmersellen
- 2010         Municipality                   Arni (AG)
- 2010         Municipality                     Cologny
- 2010         Municipality                     Nebikon
- 2010         Municipality                   Marthalen
- 2010         Municipality             Rorschacherberg
- 2010         Municipality      Châtel-sur-Montsalvens
- 2010         Municipality                     Mönthal
- 2010         Municipality                  Gletterens
- 2010         Municipality                   Densbüren
- 2010         Municipality                   Estavayer
- 2010         Municipality                    La Roche
- 2010         Municipality                        Vich
- 2010         Municipality                     Bönigen
- 2010         Municipality                 Zwieselberg
- 2010         Municipality                     Sisikon
- 2010         Municipality                     Servion
- 2010         Municipality                     Boulens
- 2010         Municipality                       Wynau
- 2010         Municipality                    Oberrüti
- 2010         Municipality                     Zetzwil
- 2010         Municipality                Hilterfingen
- 2010         Municipality                    Seftigen
- 2010         Municipality        Conters im Prättigau
- 2010         Municipality                Lantsch/Lenz
- 2010         Municipality                  Wilen (TG)
- 2010         Municipality                      Schwyz
- 2010         Municipality                  Interlaken
- 2010         Municipality                    Boncourt
- 2010         Municipality                      Trogen
- 2010         Municipality                    Chéserex
- 2010         Municipality                   Heimiswil
- 2010         Municipality                 Schleinikon
- 2010         Municipality                   Obermumpf
- 2010         Municipality                     Zwingen
- 2010         Municipality               Niedermuhlern
- 2010         Municipality                    Vulliens
- 2010         Municipality                     Penthaz
- 2010         Municipality         Hauenstein-Ifenthal
- 2010         Municipality               Val de Bagnes
- 2010         Municipality                 Würenlingen
- 2010         Municipality         Wangen-Brüttisellen
- 2010         Municipality                   Güttingen
- 2010         Municipality                 Alchenstorf
- 2010         Municipality                     Blatten
- 2010         Municipality                  Villmergen
- 2010         Municipality                      Möhlin
- 2010         Municipality           Corsier-sur-Vevey
- 2010         Municipality                Pont-en-Ogoz
- 2010         Municipality             Eschenbach (LU)
- 2010         Municipality          Hauptwil-Gottshaus
- 2010         Municipality          Corcelles-le-Jorat
- 2010         Municipality                     Le Lieu
- 2010         Municipality                    Chevroux
- 2010         Municipality                  Salenstein
- 2010         Municipality        Villars-Sainte-Croix
- 2010         Municipality              Kirchdorf (BE)
- 2010         Municipality                    Isenthal
- 2010         Municipality                    Rüschegg
- 2010         Municipality            La Tour-de-Peilz
- 2010         Municipality                  Stein (AG)
- 2010         Municipality                  Aesch (LU)
- 2010         Municipality                    Bellmund
- 2010         Municipality                Schattenhalb
- 2010         Municipality               Lauterbrunnen
- 2010         Municipality                      Fehren
- 2010         Municipality        Oberwil im Simmental
- 2010         Municipality                   Bettingen
- 2010         Municipality                    Lostallo
- 2010         Municipality                 Schübelbach
- 2010         Municipality                     Böckten
- 2010         Municipality                  Fischingen
- 2010         Municipality                    Madulain
- 2010         Municipality                    Mellikon
- 2010         Municipality                  Mont-Vully
- 2010         Municipality                      Icogne
- 2010         Municipality                    Erschwil
- 2010         Municipality                   Döttingen
- 2010         Municipality                  Langendorf
- 2010         Municipality                    Henggart
- 2010         Municipality                    Vechigen
- 2010         Municipality                    Siviriez
- 2010         Municipality          Terre di Pedemonte
- 2010         Municipality               Oberbuchsiten
- 2010         Municipality                    Bellwald
- 2010         Municipality                    Neuenegg
- 2010         Municipality                Bergdietikon
- 2010         Municipality                  Gommiswald
- 2010         Municipality                    Grenchen
- 2010         Municipality                      Rennaz
- 2010         Municipality                  Frauenfeld
- 2010         Municipality                  Matzendorf
- 2010         Municipality                    Galgenen
- 2010         Municipality                 Romont (BE)
- 2010         Municipality                      Uezwil
- 2010         Municipality                    Boécourt
- 2010         Municipality                   Luterbach
- 2010         Municipality                       Amden
- 2010         Municipality                 St. Niklaus
- 2010         Municipality                      Denges
- 2010         Municipality                Kriegstetten
- 2010         Municipality                    Giornico
- 2010         Municipality                      Savosa
- 2010         Municipality              Küssnacht (SZ)
- 2010         Municipality                    Eichberg
- 2010         Municipality                     Bioggio
- 2010         Municipality               Finsterhennen
- 2010         Municipality                   Meienried
- 2010         Municipality              Guttet-Feschel
- 2010         Municipality                        Sins
- 2010         Municipality                    Riedholz
- 2010         Municipality                        Trin
- 2010         Municipality                  Rüthi (SG)
- 2010         Municipality                        Giez
- 2010         Municipality                   Epalinges
- 2010         Municipality                  Biberstein
- 2010         Municipality                       Grône
- 2010         Municipality                   Beggingen
- 2010         Municipality                      Stadel
- 2010         Municipality               Riemenstalden
- 2010         Municipality               Schöfflisdorf
- 2010         Municipality                        Jaun
- 2010         Municipality               Mont-Tramelan
- 2010         Municipality                 Ennetbürgen
- 2010         Municipality                   Wichtrach
- 2010         Municipality                   Rochefort
- 2010         Municipality                     Mosnang
- 2010         Municipality                    Cuarnens
- 2010         Municipality                 Lütschental
- 2010         Municipality                    Willisau
- 2010         Municipality                     Saxeten
- 2010         Municipality                 Wangen (SZ)
- 2010         Municipality           Granges (Veveyse)
- 2010         Municipality                   Dittingen
- 2010         Municipality                 Zuzwil (SG)
- 2010         Municipality               Oberlangenegg
- 2010         Municipality             Bremgarten (AG)
- 2010         Municipality                      Kiesen
- 2010         Municipality                       Rovio
- 2010         Municipality             Avegno Gordevio
- 2010         Municipality                    Le Locle
- 2010         Municipality                 Weisslingen
- 2010         Municipality                  Vorderthal
- 2010         Municipality                      Berken
- 2010         Municipality                     Flüelen
- 2010         Municipality                        Sion
- 2010         Municipality                  Courtedoux
- 2010         Municipality            Lussy-sur-Morges
- 2010         Municipality                      Halten
- 2010         Municipality                   Siblingen
- 2010         Municipality                  Walenstadt
- 2010         Municipality                   Hornussen
- 2010         Municipality               Oberdorf (NW)
- 2010         Municipality                       Stans
- 2010         Municipality                     Versoix
- 2010         Municipality           Sils im Domleschg
- 2010         Municipality                  Flurlingen
- 2010         Municipality                        Mies
- 2010         Municipality                     Hittnau
- 2010         Municipality                     Vaulion
- 2010         Municipality                       Suchy
- 2010         Municipality                     Sumvitg
- 2010         Municipality                 Amsoldingen
- 2010         Municipality                   Villarzel
- 2010         Municipality                      Widnau
- 2010         Municipality                 Thunstetten
- 2010         Municipality                  Regensberg
- 2010         Municipality               Ormont-Dessus
- 2010         Municipality                 Rechthalten
- 2010         Municipality          Chavannes-le-Chêne
- 2010         Municipality                   Trüllikon
- 2010         Municipality             Warth-Weiningen
- 2010         Municipality                         Vex
- 2010         Municipality                   Fulenbach
- 2010         Municipality                 Blumenstein
- 2010         Municipality                      Sattel
- 2010         Municipality                     Leytron
- 2010         Municipality                        Elgg
- 2010         Municipality                     Itingen
- 2010         Municipality             Rapperswil (BE)
- 2010         Municipality                   Reisiswil
- 2010         Municipality                     Ersigen
- 2010         Municipality                    Oberthal
- 2010         Municipality            Birmenstorf (AG)
- 2010         Municipality                   Sumiswald
- 2010         Municipality                 Stüsslingen
- 2010         Municipality                        Trun
- 2010         Municipality        Busswil bei Melchnau
- 2010         Municipality                  Langenthal
- 2010         Municipality                     Grächen
- 2010         Municipality                    Rheineck
- 2010         Municipality                   Petit-Val
- 2010         Municipality                Häggenschwil
- 2010         Municipality                   Grengiols
- 2010         Municipality                  Greifensee
- 2010         Municipality                         Lax
- 2010         Municipality                 Adligenswil
- 2010         Municipality             Holderbank (AG)
- 2010         Municipality                      Lugano
- 2010         Municipality                      Lamone
- 2010         Municipality                 Gossau (SG)
- 2010         Municipality                    Buchrain
- 2010         Municipality                      Grüsch
- 2010         Municipality                       Agarn
- 2010         Municipality                       Bière
- 2010         Municipality                Heimenhausen
- 2010         Municipality                      Salvan
- 2010         Municipality                        Yens
- 2010         Municipality                      Bünzen
- 2010         Municipality                     Tägerig
- 2010         Municipality                  Montfaucon
- 2010         Municipality          Wangen an der Aare
- 2010         Municipality                     Pohlern
- 2010         Municipality                        Bure
- 2010         Municipality                Trubschachen
- 2010         Municipality                   Herbligen
- 2010         Municipality                  Witterswil
- 2010         Municipality                  Ormalingen
- 2010         Municipality                      Törbel
- 2010         Municipality                   Drei Höfe
- 2010         Municipality                   Wiggiswil
- 2010         Municipality                  Niederlenz
- 2010         Municipality                  Fislisbach
- 2010         Municipality                     Berneck
- 2010         Municipality              Mont-sur-Rolle
- 2010         Municipality                    Oltingen
- 2010         Municipality                   Bäretswil
- 2010         Municipality                  Grellingen
- 2010         Municipality                    Erstfeld
- 2010         Municipality                      Sierre
- 2010         Municipality                        Bern
- 2010         Municipality                Collex-Bossy
- 2010         Municipality            Unterengstringen
- 2010         Municipality                     Monthey
- 2010         Municipality                        Fahy
- 2010         Municipality                    Lausanne
- 2010         Municipality                  Buttisholz
- 2010         Municipality                  Saint-Prex
- 2010         Municipality                        Leuk
- 2010         Municipality                  Hindelbank
- 2010         Municipality                      Eysins
- 2010         Municipality                  Corbeyrier
- 2010         Municipality       Treytorrens (Payerne)
- 2010         Municipality                      Tannay
- 2010         Municipality                   Vucherens
- 2010         Municipality                  Krauchthal
- 2010         Municipality           Büren an der Aare
- 2010         Municipality                     Bonaduz
- 2010         Municipality                   Milvignes
- 2010         Municipality                     Birrwil
- 2010         Municipality                       Randa
- 2010         Municipality                   Val Terbi
- 2010         Municipality                Niedergösgen
- 2010         Municipality                     Kerzers
- 2010         Municipality                        Dorf
- 2010         Municipality                  Dörflingen
- 2010         Municipality     Saint-Saphorin (Lavaux)
- 2010         Municipality                    Fisibach
- 2010         Municipality                  Prévonloup
- 2010         Municipality                    Uerkheim
- 2010         Municipality                     Gibloux
- 2010         Municipality                  Buchs (ZH)
- 2010         Municipality        Valeyres-sous-Rances
- 2010         Municipality      Corcelles-près-Concise
- 2010         Municipality                 Hohentannen
- 2010         Municipality                   Altendorf
- 2010         Municipality                   Berlingen
- 2010         Municipality             Oberengstringen
- 2010         Municipality        Schwanden bei Brienz
- 2010         Municipality                    Russikon
- 2010         Municipality                      Vinzel
- 2010         Municipality                  Flumenthal
- 2010         Municipality   Niederried bei Interlaken
- 2010         Municipality                   Pompaples
- 2010         Municipality                    Thundorf
- 2010         Municipality                     Rüegsau
- 2010         Municipality                  Mettembert
- 2010         Municipality                      Astano
- 2010         Municipality                   Berg (SG)
- 2010         Municipality              Schmitten (GR)
- 2010         Municipality               Vilters-Wangs
- 2010         Municipality                  Neftenbach
- 2010         Municipality                     Mammern
- 2010         Municipality                    Brislach
- 2010         Municipality                    Tavannes
- 2010         Municipality               Oberdorf (BL)
- 2010         Municipality                Spreitenbach
- 2010         Municipality                  Ederswiler
- 2010         Municipality                Saint-Blaise
- 2010         Municipality                   Mervelier
- 2010         Municipality                        Rüte
- 2010         Municipality                     Moutier
- 2010         Municipality                  Seelisberg
- 2010         Municipality                    Boussens
- 2010         Municipality      Valeyres-sous-Montagny
- 2010         Municipality                  Hüttlingen
- 2010         Municipality                       Widen
- 2010         Municipality                       Büron
- 2010         Municipality               Saas-Almagell
- 2010         Municipality                        Arch
- 2010         Municipality                  Pfeffingen
- 2010         Municipality                      Reiden
- 2010         Municipality                     Gunzgen
- 2010         Municipality                 Merishausen
- 2010         Municipality                  Herrliberg
- 2010         Municipality                      Lindau
- 2010         Municipality                   Bovernier
- 2010         Municipality                  Saas-Grund
- 2010         Municipality              Dompierre (VD)
- 2010         Municipality         Chavannes-le-Veyron
- 2010         Municipality                      L'Isle
- 2010         Municipality    Reichenbach im Kandertal
- 2010         Municipality                      Künten
- 2010         Municipality                     Payerne
- 2010         Municipality                    Rohrbach
- 2010         Municipality                   Leibstadt
- 2010         Municipality       Chavannes-près-Renens
- 2010         Municipality                  Ballaigues
- 2010         Municipality      Röthenbach im Emmental
- 2010         Municipality                       Gilly
- 2010         Municipality               Innertkirchen
- 2010         Municipality                     Begnins
- 2010         Municipality                      Bühler
- 2010         Municipality              Jorat-Mézières
- 2010         Municipality                 La Ferrière
- 2010         Municipality                       Honau
- 2010         Municipality                Saint-George
- 2010         Municipality                      Sarnen
- 2010         Municipality              Bioley-Magnoux
- 2010         Municipality                      Muolen
- 2010         Municipality                    La Sagne
- 2010         Municipality                  Lampenberg
- 2010         Municipality                      Buseno
- 2010         Municipality                        Horw
- 2010         Municipality                Steg-Hohtenn
- 2010         Municipality                      Crésuz
- 2010         Municipality                   Echarlens
- 2010         Municipality                      Neggio
- 2010         Municipality                   Hospental
- 2010         Municipality                Wintersingen
- 2010         Municipality                   Duggingen
- 2010         Municipality                     Savièse
- 2010         Municipality                   Buch (SH)
- 2010         Municipality                     Diegten
- 2010         Municipality                      Bullet
- 2010         Municipality                 Moosseedorf
- 2010         Municipality                      Saulcy
- 2010         Municipality               Montagny (FR)
- 2010         Municipality               Basse-Allaine
- 2010         Municipality                    Bellevue
- 2010         Municipality                        Dizy
- 2010         Municipality                     Yvonand
- 2010         Municipality                      Thônex
- 2010         Municipality                 Kappel (SO)
- 2010         Municipality                      Gersau
- 2010         Municipality                      Lausen
- 2010         Municipality                    Rebstein
- 2010         Municipality             Aeugst am Albis
- 2010         Municipality                    Orselina
- 2010         Municipality                     Zermatt
- 2010         Municipality                Wileroltigen
- 2010         Municipality             Riva San Vitale
- 2010         Municipality                 Maschwanden
- 2010         Municipality                     Lauenen
- 2010         Municipality             Lussery-Villars
- 2010         Municipality                      Soubey
- 2010         Municipality                    Elfingen
- 2010         Municipality                    Egliswil
- 2010         Municipality                        Pomy
- 2010         Municipality          Niederhelfenschwil
- 2010         Municipality                    Kappelen
- 2010         Municipality                  Stein (AR)
- 2010         Municipality      Fontaines-sur-Grandson
- 2010         Municipality                 Trasadingen
- 2010         Municipality                       Ollon
- 2010         Municipality                    Holziken
- 2010         Municipality                     Samedan
- 2010         Municipality                       Baden
- 2010         Municipality                 Rüeggisberg
- 2010         Municipality                    Buchberg
- 2010         Municipality                    Burgdorf
- 2010         Municipality                    Lufingen
- 2010         Municipality                  Guggisberg
- 2010         Municipality                        Onex
- 2010         Municipality                        Agno
- 2010         Municipality                    Büttikon
- 2010         Municipality               Muri bei Bern
- 2010         Municipality                   Grub (AR)
- 2010         Municipality                   Brig-Glis
- 2010         Municipality                  Ueberstorf
- 2010         Municipality                   Freienwil
- 2010         Municipality                    Horriwil
- 2010         Municipality                     Menznau
- 2010         Municipality                     Zuchwil
- 2010         Municipality                     Braunau
- 2010         Municipality                     Hallwil
- 2010         Municipality                     Grindel
- 2010         Municipality                Cottens (FR)
- 2010         Municipality                 Kirchleerau
- 2010         Municipality                 Kaiserstuhl
- 2010         Municipality                    Schenkon
- 2010         Municipality               Aire-la-Ville
- 2010         Municipality                      Bister
- 2010         Municipality      Corcelles-près-Payerne
- 2010         Municipality                     Bissone
- 2010         Municipality                        Goms
- 2010         Municipality                     Pfungen
- 2010         Municipality                Reinach (BL)
- 2010         Municipality                   Maisprach
- 2010         Municipality                   Oensingen
- 2010         Municipality             Kappel am Albis
- 2010         Municipality                     Bettens
- 2010         Municipality                  Turbenthal
- 2010         Municipality                 Kriechenwil
- 2010         Municipality                  Senarclens
- 2010         Municipality                    Uebeschi
- 2010         Municipality                   Bottenwil
- 2010         Municipality                      Meyrin
- 2010         Municipality                     Dorénaz
- 2010         Municipality                     Henniez
- 2010         Municipality                     Brunegg
- 2010         Municipality                    Oberkulm
- 2010         Municipality                    Trimbach
- 2010         Municipality                     Siselen
- 2010         Municipality                 Mönchaltorf
- 2010         Municipality             Münchwilen (TG)
- 2010         Municipality                  Hermenches
- 2010         Municipality                 Hendschiken
- 2010         Municipality                Prévondavaux
- 2010         Municipality             Hofstetten-Flüh
- 2010         Municipality                  Lützelflüh
- 2010         Municipality                  Himmelried
- 2010         Municipality                       Sâles
- 2010         Municipality                 Wallisellen
- 2010         Municipality                  Vordemwald
- 2010         Municipality                     Grolley
- 2010         Municipality                   Mergoscia
- 2010         Municipality                   Rongellen
- 2010         Municipality                      Zuzgen
- 2010         Municipality                  Gambarogno
- 2010         Municipality                  Einsiedeln
- 2010         Municipality                       Vezia
- 2010         Municipality              Uetikon am See
- 2010         Municipality                    Chamblon
- 2010         Municipality                      Airolo
- 2010         Municipality             Wolfenschiessen
- 2010         Municipality                  Hägglingen
- 2010         Municipality             Herzogenbuchsee
- 2010         Municipality                       Täsch
- 2010         Municipality                      Vouvry
- 2010         Municipality            Morbio Inferiore
- 2010         Municipality                     Rümikon
- 2010         Municipality                      Weggis
- 2010         Municipality                    Wolhusen
- 2010         Municipality                  Châtonnaye
- 2010         Municipality              Gipf-Oberfrick
- 2010         Municipality                   Männedorf
- 2010         Municipality                      Riehen
- 2010         Municipality                 Feuerthalen
- 2010         Municipality                     Calanca
- 2010         Municipality                    Lenzburg
- 2010         Municipality                   Matzingen
- 2010         Municipality                       Bever
- 2010         Municipality                 Kammersrohr
- 2010         Municipality                  Silvaplana
- 2010         Municipality                      Flawil
- 2010         Municipality                     Muriaux
- 2010         Municipality          Torricella-Taverne
- 2010         Municipality                    Liesberg
- 2010         Municipality                    Amriswil
- 2010         Municipality              Cugnasco-Gerra
- 2010         Municipality               Roveredo (GR)
- 2010         Municipality                  Saas-Balen
- 2010         Municipality                  Dürrenäsch
- 2010         Municipality          La Chaux-du-Milieu
- 2010         Municipality                    Oeschgen
- 2010         Municipality              Schlatt-Haslen
- 2010         Municipality                  Fahrwangen
- 2010         Municipality                   Hägendorf
- 2010         Municipality                    Vérossaz
- 2010         Municipality         Campo (Vallemaggia)
- 2010         Municipality                         Egg
- 2010         Municipality               Münsterlingen
- 2010         Municipality                   Massongex
- 2010         Municipality                  Diemerswil
- 2010         Municipality                    Emmetten
- 2010         Municipality                Vico Morcote
- 2010         Municipality                   Meiringen
- 2010         Municipality                      Tafers
- 2010         Municipality                   La Sarraz
- 2010         Municipality            Langnau am Albis
- 2010         Municipality                     Anières
- 2010         Municipality                    Stettlen
- 2010         Municipality                    Dällikon
- 2010         Municipality                       Pully
- 2010         Municipality                 Rumendingen
- 2010         Municipality               Ecublens (VD)
- 2010         Municipality              Gampel-Bratsch
- 2010         Municipality                  Aesch (BL)
- 2010         Municipality             Wohlen bei Bern
- 2010         Municipality                   Dielsdorf
- 2010         Municipality              Granges-Paccot
- 2010         Municipality                      Blenio
- 2010         Municipality                     Céligny
- 2010         Municipality                       Emmen
- 2010         Municipality                     Etziken
- 2010         Municipality                        Wila
- 2010         Municipality                      Magden
- 2010         Municipality                   Adelboden
- 2010         Municipality                     Gisikon
- 2010         Municipality                     Vuadens
- 2010         Municipality                       Erlen
- 2010         Municipality               Villorsonnens
- 2010         Municipality                   Echandens
- 2010         Municipality                  Walperswil
- 2010         Municipality              Kilchberg (ZH)
- 2010         Municipality                Val-d'Illiez
- 2010         Municipality                    Würenlos
- 2010         Municipality                 Udligenswil
- 2010         Municipality                       Bodio
- 2010         Municipality                  Courtelary
- 2010         Municipality                     Oberems
- 2010         Municipality                 Andelfingen
- 2010         Municipality                    Chexbres
- 2010         Municipality                    Walchwil
- 2010         Municipality                  Meinisberg
- 2010         Municipality                       Flums
- 2010         Municipality                      Eisten
- 2010         Municipality                      Termen
- 2010         Municipality                     Champoz
- 2010         Municipality                Münchenstein
- 2010         Municipality                    L'Abbaye
- 2010         Municipality             Misery-Courtion
- 2010         Municipality                    Zofingen
- 2010         Municipality                        Ursy
- 2010         Municipality                Bretonnières
- 2010         Municipality                   Truttikon
- 2010         Municipality                    Steinach
- 2010         Municipality                  Courchavon
- 2010         Municipality                 Courchapoix
- 2010         Municipality                  Winterthur
- 2010         Municipality                   Härkingen
- 2010         Municipality                  Schattdorf
- 2010         Municipality              Schwarzhäusern
- 2010         Municipality                    Effingen
- 2010         Municipality                      Chigny
- 2010         Municipality                    Koppigen
- 2010         Municipality                    Presinge
- 2010         Municipality                   Lütisburg
- 2010         Municipality                     Hemberg
- 2010         Municipality                        Prez
- 2010         Municipality                       Fully
- 2010         Municipality               St. Silvester
- 2010         Municipality                   Oberägeri
- 2010         Municipality                      Seewen
- 2010         Municipality                     Aubonne
- 2010         Municipality                  Büren (SO)
- 2010         Municipality                    Suscévaz
- 2010         Municipality                       Ulmiz
- 2010         Municipality                        Etoy
- 2010         Municipality                 Sembrancher
- 2010         Municipality                     Staufen
- 2010         Municipality                Stalden (VS)
- 2010         Municipality                        Belp
- 2010         Municipality                      Denens
- 2010         Municipality                    Chamoson
- 2010         Municipality               Crans-Montana
- 2010         Municipality                     Mörigen
- 2010         Municipality               Schwerzenbach
- 2010         Municipality                       Bowil
-               population_type place_of_birth amount
- Permanent resident population         Abroad    117
- Permanent resident population         Abroad    115
- Permanent resident population         Abroad   1565
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad    181
- Permanent resident population         Abroad    714
- Permanent resident population         Abroad   2324
- Permanent resident population         Abroad    120
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad    154
- Permanent resident population         Abroad    128
- Permanent resident population         Abroad     89
- Permanent resident population         Abroad    136
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad    970
- Permanent resident population         Abroad    126
- Permanent resident population         Abroad   1301
- Permanent resident population         Abroad    247
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad    187
- Permanent resident population         Abroad   2557
- Permanent resident population         Abroad   1198
- Permanent resident population         Abroad  10720
- Permanent resident population         Abroad    164
- Permanent resident population         Abroad     98
- Permanent resident population         Abroad     72
- Permanent resident population         Abroad   3144
- Permanent resident population         Abroad     86
- Permanent resident population         Abroad    196
- Permanent resident population         Abroad     41
- Permanent resident population         Abroad    632
- Permanent resident population         Abroad    112
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad    273
- Permanent resident population         Abroad    136
- Permanent resident population         Abroad    462
- Permanent resident population         Abroad    394
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad    524
- Permanent resident population         Abroad    118
- Permanent resident population         Abroad    202
- Permanent resident population         Abroad   2425
- Permanent resident population         Abroad    345
- Permanent resident population         Abroad    782
- Permanent resident population         Abroad    142
- Permanent resident population         Abroad    822
- Permanent resident population         Abroad    528
- Permanent resident population         Abroad     38
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad    544
- Permanent resident population         Abroad   1625
- Permanent resident population         Abroad    209
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad   1452
- Permanent resident population         Abroad    561
- Permanent resident population         Abroad     80
- Permanent resident population         Abroad     41
- Permanent resident population         Abroad    491
- Permanent resident population         Abroad    346
- Permanent resident population         Abroad    325
- Permanent resident population         Abroad     75
- Permanent resident population         Abroad    183
- Permanent resident population         Abroad     16
- Permanent resident population         Abroad   3260
- Permanent resident population         Abroad    100
- Permanent resident population         Abroad     52
- Permanent resident population         Abroad    930
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad    216
- Permanent resident population         Abroad    115
- Permanent resident population         Abroad     65
- Permanent resident population         Abroad   1193
- Permanent resident population         Abroad   1373
- Permanent resident population         Abroad   3606
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad   1437
- Permanent resident population         Abroad    157
- Permanent resident population         Abroad    647
- Permanent resident population         Abroad    871
- Permanent resident population         Abroad    255
- Permanent resident population         Abroad     54
- Permanent resident population         Abroad     29
- Permanent resident population         Abroad   2372
- Permanent resident population         Abroad    355
- Permanent resident population         Abroad    144
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad    365
- Permanent resident population         Abroad     48
- Permanent resident population         Abroad    140
- Permanent resident population         Abroad   5579
- Permanent resident population         Abroad    303
- Permanent resident population         Abroad    609
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad    329
- Permanent resident population         Abroad     76
- Permanent resident population         Abroad     25
- Permanent resident population         Abroad   1016
- Permanent resident population         Abroad     15
- Permanent resident population         Abroad    381
- Permanent resident population         Abroad    745
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad   1264
- Permanent resident population         Abroad    230
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad     93
- Permanent resident population         Abroad    359
- Permanent resident population         Abroad     99
- Permanent resident population         Abroad     11
- Permanent resident population         Abroad   2770
- Permanent resident population         Abroad   4655
- Permanent resident population         Abroad   8715
- Permanent resident population         Abroad     62
- Permanent resident population         Abroad    131
- Permanent resident population         Abroad    370
- Permanent resident population         Abroad    482
- Permanent resident population         Abroad   2963
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad    620
- Permanent resident population         Abroad    312
- Permanent resident population         Abroad   1316
- Permanent resident population         Abroad     54
- Permanent resident population         Abroad    156
- Permanent resident population         Abroad     41
- Permanent resident population         Abroad   3780
- Permanent resident population         Abroad   1234
- Permanent resident population         Abroad   1731
- Permanent resident population         Abroad    195
- Permanent resident population         Abroad    209
- Permanent resident population         Abroad     99
- Permanent resident population         Abroad    589
- Permanent resident population         Abroad    302
- Permanent resident population         Abroad    517
- Permanent resident population         Abroad    202
- Permanent resident population         Abroad    113
- Permanent resident population         Abroad   1191
- Permanent resident population         Abroad    230
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad     94
- Permanent resident population         Abroad     80
- Permanent resident population         Abroad    293
- Permanent resident population         Abroad    646
- Permanent resident population         Abroad    120
- Permanent resident population         Abroad    239
- Permanent resident population         Abroad    390
- Permanent resident population         Abroad    625
- Permanent resident population         Abroad   1549
- Permanent resident population         Abroad    429
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad     67
- Permanent resident population         Abroad     56
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad    154
- Permanent resident population         Abroad    320
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad    360
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad   2399
- Permanent resident population         Abroad    258
- Permanent resident population         Abroad    302
- Permanent resident population         Abroad     22
- Permanent resident population         Abroad    155
- Permanent resident population         Abroad    124
- Permanent resident population         Abroad    186
- Permanent resident population         Abroad    545
- Permanent resident population         Abroad    194
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad     58
- Permanent resident population         Abroad    728
- Permanent resident population         Abroad   5293
- Permanent resident population         Abroad   3919
- Permanent resident population         Abroad     23
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad     39
- Permanent resident population         Abroad    332
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad    732
- Permanent resident population         Abroad    106
- Permanent resident population         Abroad   2682
- Permanent resident population         Abroad     94
- Permanent resident population         Abroad    176
- Permanent resident population         Abroad     61
- Permanent resident population         Abroad      8
- Permanent resident population         Abroad    126
- Permanent resident population         Abroad   1775
- Permanent resident population         Abroad   4775
- Permanent resident population         Abroad     61
- Permanent resident population         Abroad     56
- Permanent resident population         Abroad   6613
- Permanent resident population         Abroad   1394
- Permanent resident population         Abroad     21
- Permanent resident population         Abroad   1164
- Permanent resident population         Abroad    163
- Permanent resident population         Abroad     96
- Permanent resident population         Abroad      9
- Permanent resident population         Abroad    638
- Permanent resident population         Abroad     74
- Permanent resident population         Abroad    341
- Permanent resident population         Abroad     19
- Permanent resident population         Abroad      4
- Permanent resident population         Abroad    180
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad    222
- Permanent resident population         Abroad    717
- Permanent resident population         Abroad     34
- Permanent resident population         Abroad    843
- Permanent resident population         Abroad    143
- Permanent resident population         Abroad    116
- Permanent resident population         Abroad    775
- Permanent resident population         Abroad     72
- Permanent resident population         Abroad    113
- Permanent resident population         Abroad    101
- Permanent resident population         Abroad    327
- Permanent resident population         Abroad   1112
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad    197
- Permanent resident population         Abroad    110
- Permanent resident population         Abroad    123
- Permanent resident population         Abroad    374
- Permanent resident population         Abroad   1966
- Permanent resident population         Abroad   1500
- Permanent resident population         Abroad    185
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad    353
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad    395
- Permanent resident population         Abroad      5
- Permanent resident population         Abroad  23848
- Permanent resident population         Abroad    210
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad   2736
- Permanent resident population         Abroad     88
- Permanent resident population         Abroad    132
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad    381
- Permanent resident population         Abroad    510
- Permanent resident population         Abroad   1867
- Permanent resident population         Abroad    252
- Permanent resident population         Abroad    332
- Permanent resident population         Abroad    274
- Permanent resident population         Abroad    405
- Permanent resident population         Abroad    182
- Permanent resident population         Abroad    777
- Permanent resident population         Abroad    469
- Permanent resident population         Abroad     29
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad   4694
- Permanent resident population         Abroad    143
- Permanent resident population         Abroad     22
- Permanent resident population         Abroad     84
- Permanent resident population         Abroad    731
- Permanent resident population         Abroad   1092
- Permanent resident population         Abroad    216
- Permanent resident population         Abroad    138
- Permanent resident population         Abroad    341
- Permanent resident population         Abroad    184
- Permanent resident population         Abroad    105
- Permanent resident population         Abroad   1450
- Permanent resident population         Abroad    263
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad    107
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad     54
- Permanent resident population         Abroad     93
- Permanent resident population         Abroad    153
- Permanent resident population         Abroad   2377
- Permanent resident population         Abroad   1819
- Permanent resident population         Abroad    278
- Permanent resident population         Abroad    736
- Permanent resident population         Abroad    897
- Permanent resident population         Abroad    153
- Permanent resident population         Abroad     91
- Permanent resident population         Abroad     86
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad    129
- Permanent resident population         Abroad    439
- Permanent resident population         Abroad     90
- Permanent resident population         Abroad   1801
- Permanent resident population         Abroad     96
- Permanent resident population         Abroad    144
- Permanent resident population         Abroad    219
- Permanent resident population         Abroad    127
- Permanent resident population         Abroad    663
- Permanent resident population         Abroad    130
- Permanent resident population         Abroad   7632
- Permanent resident population         Abroad    211
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad     98
- Permanent resident population         Abroad      6
- Permanent resident population         Abroad    441
- Permanent resident population         Abroad     68
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad    226
- Permanent resident population         Abroad    186
- Permanent resident population         Abroad   1240
- Permanent resident population         Abroad    652
- Permanent resident population         Abroad  11660
- Permanent resident population         Abroad    169
- Permanent resident population         Abroad    520
- Permanent resident population         Abroad    397
- Permanent resident population         Abroad   1688
- Permanent resident population         Abroad     81
- Permanent resident population         Abroad    195
- Permanent resident population         Abroad    491
- Permanent resident population         Abroad    304
- Permanent resident population         Abroad    719
- Permanent resident population         Abroad    754
- Permanent resident population         Abroad    135
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad     50
- Permanent resident population         Abroad     38
- Permanent resident population         Abroad     47
- Permanent resident population         Abroad   2988
- Permanent resident population         Abroad     95
- Permanent resident population         Abroad     60
- Permanent resident population         Abroad    378
- Permanent resident population         Abroad    484
- Permanent resident population         Abroad     62
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad   2640
- Permanent resident population         Abroad    393
- Permanent resident population         Abroad    272
- Permanent resident population         Abroad    439
- Permanent resident population         Abroad   1083
- Permanent resident population         Abroad    642
- Permanent resident population         Abroad   1761
- Permanent resident population         Abroad      6
- Permanent resident population         Abroad     45
- Permanent resident population         Abroad     37
- Permanent resident population         Abroad     91
- Permanent resident population         Abroad    676
- Permanent resident population         Abroad   1126
- Permanent resident population         Abroad    987
- Permanent resident population         Abroad    137
- Permanent resident population         Abroad    136
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad    371
- Permanent resident population         Abroad    283
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad    482
- Permanent resident population         Abroad  65213
- Permanent resident population         Abroad    288
- Permanent resident population         Abroad    156
- Permanent resident population         Abroad    123
- Permanent resident population         Abroad    160
- Permanent resident population         Abroad    185
- Permanent resident population         Abroad   1364
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad    227
- Permanent resident population         Abroad    402
- Permanent resident population         Abroad     29
- Permanent resident population         Abroad    176
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad   3868
- Permanent resident population         Abroad    636
- Permanent resident population         Abroad    286
- Permanent resident population         Abroad    544
- Permanent resident population         Abroad    364
- Permanent resident population         Abroad   1405
- Permanent resident population         Abroad    358
- Permanent resident population         Abroad    634
- Permanent resident population         Abroad    167
- Permanent resident population         Abroad    807
- Permanent resident population         Abroad    334
- Permanent resident population         Abroad      8
- Permanent resident population         Abroad   2434
- Permanent resident population         Abroad    121
- Permanent resident population         Abroad    871
- Permanent resident population         Abroad     57
- Permanent resident population         Abroad    888
- Permanent resident population         Abroad    456
- Permanent resident population         Abroad    114
- Permanent resident population         Abroad    186
- Permanent resident population         Abroad    351
- Permanent resident population         Abroad    111
- Permanent resident population         Abroad   1209
- Permanent resident population         Abroad    279
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad    312
- Permanent resident population         Abroad   1058
- Permanent resident population         Abroad    315
- Permanent resident population         Abroad   3486
- Permanent resident population         Abroad   1167
- Permanent resident population         Abroad    896
- Permanent resident population         Abroad   1648
- Permanent resident population         Abroad     26
- Permanent resident population         Abroad   1541
- Permanent resident population         Abroad    594
- Permanent resident population         Abroad     52
- Permanent resident population         Abroad    157
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad     94
- Permanent resident population         Abroad    989
- Permanent resident population         Abroad     15
- Permanent resident population         Abroad     29
- Permanent resident population         Abroad  12836
- Permanent resident population         Abroad   1286
- Permanent resident population         Abroad    117
- Permanent resident population         Abroad    661
- Permanent resident population         Abroad     66
- Permanent resident population         Abroad    444
- Permanent resident population         Abroad    590
- Permanent resident population         Abroad      3
- Permanent resident population         Abroad    197
- Permanent resident population         Abroad    173
- Permanent resident population         Abroad  16396
- Permanent resident population         Abroad    395
- Permanent resident population         Abroad    439
- Permanent resident population         Abroad     38
- Permanent resident population         Abroad   4296
- Permanent resident population         Abroad    150
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad     12
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad    535
- Permanent resident population         Abroad    115
- Permanent resident population         Abroad     55
- Permanent resident population         Abroad    141
- Permanent resident population         Abroad    846
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad     88
- Permanent resident population         Abroad   1251
- Permanent resident population         Abroad    225
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad     14
- Permanent resident population         Abroad    307
- Permanent resident population         Abroad    102
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad    247
- Permanent resident population         Abroad     34
- Permanent resident population         Abroad     81
- Permanent resident population         Abroad    524
- Permanent resident population         Abroad   2170
- Permanent resident population         Abroad   1055
- Permanent resident population         Abroad    178
- Permanent resident population         Abroad      1
- Permanent resident population         Abroad    144
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad   1267
- Permanent resident population         Abroad    244
- Permanent resident population         Abroad   1120
- Permanent resident population         Abroad     89
- Permanent resident population         Abroad    326
- Permanent resident population         Abroad    304
- Permanent resident population         Abroad     89
- Permanent resident population         Abroad   2228
- Permanent resident population         Abroad   1146
- Permanent resident population         Abroad   1115
- Permanent resident population         Abroad     47
- Permanent resident population         Abroad    319
- Permanent resident population         Abroad     49
- Permanent resident population         Abroad    215
- Permanent resident population         Abroad    294
- Permanent resident population         Abroad     59
- Permanent resident population         Abroad     65
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad    234
- Permanent resident population         Abroad    161
- Permanent resident population         Abroad    401
- Permanent resident population         Abroad    135
- Permanent resident population         Abroad     75
- Permanent resident population         Abroad    141
- Permanent resident population         Abroad      3
- Permanent resident population         Abroad     22
- Permanent resident population         Abroad     74
- Permanent resident population         Abroad     90
- Permanent resident population         Abroad    232
- Permanent resident population         Abroad    171
- Permanent resident population         Abroad    369
- Permanent resident population         Abroad    237
- Permanent resident population         Abroad   8265
- Permanent resident population         Abroad   4323
- Permanent resident population         Abroad    150
- Permanent resident population         Abroad     75
- Permanent resident population         Abroad     48
- Permanent resident population         Abroad    300
- Permanent resident population         Abroad    111
- Permanent resident population         Abroad    219
- Permanent resident population         Abroad    375
- Permanent resident population         Abroad   3710
- Permanent resident population         Abroad   2162
- Permanent resident population         Abroad   1216
- Permanent resident population         Abroad    636
- Permanent resident population         Abroad     75
- Permanent resident population         Abroad    915
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad    405
- Permanent resident population         Abroad   5863
- Permanent resident population         Abroad    127
- Permanent resident population         Abroad     95
- Permanent resident population         Abroad   2684
- Permanent resident population         Abroad    200
- Permanent resident population         Abroad    417
- Permanent resident population         Abroad    739
- Permanent resident population         Abroad    217
- Permanent resident population         Abroad    764
- Permanent resident population         Abroad    681
- Permanent resident population         Abroad    101
- Permanent resident population         Abroad    298
- Permanent resident population         Abroad    104
- Permanent resident population         Abroad    260
- Permanent resident population         Abroad    556
- Permanent resident population         Abroad    965
- Permanent resident population         Abroad     54
- Permanent resident population         Abroad    329
- Permanent resident population         Abroad    215
- Permanent resident population         Abroad    845
- Permanent resident population         Abroad    273
- Permanent resident population         Abroad    302
- Permanent resident population         Abroad     37
- Permanent resident population         Abroad    792
- Permanent resident population         Abroad    124
- Permanent resident population         Abroad     55
- Permanent resident population         Abroad    165
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad     89
- Permanent resident population         Abroad     54
- Permanent resident population         Abroad   1369
- Permanent resident population         Abroad     37
- Permanent resident population         Abroad    144
- Permanent resident population         Abroad     80
- Permanent resident population         Abroad    353
- Permanent resident population         Abroad     28
- Permanent resident population         Abroad    216
- Permanent resident population         Abroad   1755
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad   1887
- Permanent resident population         Abroad    429
- Permanent resident population         Abroad   1721
- Permanent resident population         Abroad   3185
- Permanent resident population         Abroad    679
- Permanent resident population         Abroad   2218
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad    203
- Permanent resident population         Abroad    638
- Permanent resident population         Abroad    582
- Permanent resident population         Abroad   2010
- Permanent resident population         Abroad 104462
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad    234
- Permanent resident population         Abroad    353
- Permanent resident population         Abroad    907
- Permanent resident population         Abroad    358
- Permanent resident population         Abroad    523
- Permanent resident population         Abroad     15
- Permanent resident population         Abroad    146
- Permanent resident population         Abroad     67
- Permanent resident population         Abroad    590
- Permanent resident population         Abroad    180
- Permanent resident population         Abroad    113
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad    472
- Permanent resident population         Abroad     61
- Permanent resident population         Abroad     26
- Permanent resident population         Abroad     42
- Permanent resident population         Abroad    195
- Permanent resident population         Abroad    515
- Permanent resident population         Abroad   1190
- Permanent resident population         Abroad     55
- Permanent resident population         Abroad    224
- Permanent resident population         Abroad    958
- Permanent resident population         Abroad   1359
- Permanent resident population         Abroad   1539
- Permanent resident population         Abroad    390
- Permanent resident population         Abroad    241
- Permanent resident population         Abroad   2150
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad     19
- Permanent resident population         Abroad    608
- Permanent resident population         Abroad   2306
- Permanent resident population         Abroad    705
- Permanent resident population         Abroad    381
- Permanent resident population         Abroad    338
- Permanent resident population         Abroad     47
- Permanent resident population         Abroad    135
- Permanent resident population         Abroad    352
- Permanent resident population         Abroad    309
- Permanent resident population         Abroad   1407
- Permanent resident population         Abroad     94
- Permanent resident population         Abroad     21
- Permanent resident population         Abroad     88
- Permanent resident population         Abroad    148
- Permanent resident population         Abroad   1260
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad    163
- Permanent resident population         Abroad    121
- Permanent resident population         Abroad   1208
- Permanent resident population         Abroad    637
- Permanent resident population         Abroad    337
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad   3390
- Permanent resident population         Abroad     90
- Permanent resident population         Abroad 144642
- Permanent resident population         Abroad     23
- Permanent resident population         Abroad    156
- Permanent resident population         Abroad     97
- Permanent resident population         Abroad     97
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad   2429
- Permanent resident population         Abroad    303
- Permanent resident population         Abroad    396
- Permanent resident population         Abroad    453
- Permanent resident population         Abroad    524
- Permanent resident population         Abroad   1230
- Permanent resident population         Abroad   1959
- Permanent resident population         Abroad    176
- Permanent resident population         Abroad    177
- Permanent resident population         Abroad    378
- Permanent resident population         Abroad    111
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad    123
- Permanent resident population         Abroad   1322
- Permanent resident population         Abroad     23
- Permanent resident population         Abroad     19
- Permanent resident population         Abroad    290
- Permanent resident population         Abroad    560
- Permanent resident population         Abroad   1174
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad     57
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad   1777
- Permanent resident population         Abroad    255
- Permanent resident population         Abroad     12
- Permanent resident population         Abroad    522
- Permanent resident population         Abroad    413
- Permanent resident population         Abroad     65
- Permanent resident population         Abroad     14
- Permanent resident population         Abroad    216
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad    308
- Permanent resident population         Abroad    169
- Permanent resident population         Abroad    222
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad   3036
- Permanent resident population         Abroad   5437
- Permanent resident population         Abroad     44
- Permanent resident population         Abroad   5932
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad     55
- Permanent resident population         Abroad      9
- Permanent resident population         Abroad    134
- Permanent resident population         Abroad    184
- Permanent resident population         Abroad    890
- Permanent resident population         Abroad    925
- Permanent resident population         Abroad     99
- Permanent resident population         Abroad     88
- Permanent resident population         Abroad    199
- Permanent resident population         Abroad     81
- Permanent resident population         Abroad    124
- Permanent resident population         Abroad    202
- Permanent resident population         Abroad   4681
- Permanent resident population         Abroad     58
- Permanent resident population         Abroad    342
- Permanent resident population         Abroad   1141
- Permanent resident population         Abroad     25
- Permanent resident population         Abroad     94
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad    143
- Permanent resident population         Abroad     97
- Permanent resident population         Abroad    110
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad    308
- Permanent resident population         Abroad     41
- Permanent resident population         Abroad     31
- Permanent resident population         Abroad   5228
- Permanent resident population         Abroad   2143
- Permanent resident population         Abroad    148
- Permanent resident population         Abroad    245
- Permanent resident population         Abroad    398
- Permanent resident population         Abroad   1572
- Permanent resident population         Abroad    130
- Permanent resident population         Abroad    137
- Permanent resident population         Abroad    889
- Permanent resident population         Abroad   2231
- Permanent resident population         Abroad    844
- Permanent resident population         Abroad    963
- Permanent resident population         Abroad   1402
- Permanent resident population         Abroad     38
- Permanent resident population         Abroad    457
- Permanent resident population         Abroad     85
- Permanent resident population         Abroad    952
- Permanent resident population         Abroad     44
- Permanent resident population         Abroad   3145
- Permanent resident population         Abroad   1289
- Permanent resident population         Abroad   1202
- Permanent resident population         Abroad    538
- Permanent resident population         Abroad   1432
- Permanent resident population         Abroad    411
- Permanent resident population         Abroad     26
- Permanent resident population         Abroad    189
- Permanent resident population         Abroad     21
- Permanent resident population         Abroad      9
- Permanent resident population         Abroad    279
- Permanent resident population         Abroad    123
- Permanent resident population         Abroad    296
- Permanent resident population         Abroad     14
- Permanent resident population         Abroad    684
- Permanent resident population         Abroad    118
- Permanent resident population         Abroad   1461
- Permanent resident population         Abroad    426
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad    445
- Permanent resident population         Abroad     38
- Permanent resident population         Abroad    848
- Permanent resident population         Abroad    720
- Permanent resident population         Abroad   1692
- Permanent resident population         Abroad    946
- Permanent resident population         Abroad     97
- Permanent resident population         Abroad    379
- Permanent resident population         Abroad   9622
- Permanent resident population         Abroad   2599
- Permanent resident population         Abroad    763
- Permanent resident population         Abroad    663
- Permanent resident population         Abroad    102
- Permanent resident population         Abroad    211
- Permanent resident population         Abroad   1568
- Permanent resident population         Abroad    180
- Permanent resident population         Abroad   6132
- Permanent resident population         Abroad     78
- Permanent resident population         Abroad     45
- Permanent resident population         Abroad   1396
- Permanent resident population         Abroad    243
- Permanent resident population         Abroad   1318
- Permanent resident population         Abroad     49
- Permanent resident population         Abroad    426
- Permanent resident population         Abroad     45
- Permanent resident population         Abroad   6092
- Permanent resident population         Abroad   1751
- Permanent resident population         Abroad   1055
- Permanent resident population         Abroad     55
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad    564
- Permanent resident population         Abroad    937
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad   3429
- Permanent resident population         Abroad    240
- Permanent resident population         Abroad    927
- Permanent resident population         Abroad    458
- Permanent resident population         Abroad    368
- Permanent resident population         Abroad  16868
- Permanent resident population         Abroad      3
- Permanent resident population         Abroad    106
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad     74
- Permanent resident population         Abroad    126
- Permanent resident population         Abroad    277
- Permanent resident population         Abroad   2342
- Permanent resident population         Abroad    286
- Permanent resident population         Abroad    619
- Permanent resident population         Abroad    104
- Permanent resident population         Abroad    339
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad    166
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad     50
- Permanent resident population         Abroad    247
- Permanent resident population         Abroad  12283
- Permanent resident population         Abroad    122
- Permanent resident population         Abroad    816
- Permanent resident population         Abroad    540
- Permanent resident population         Abroad   1413
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad    119
- Permanent resident population         Abroad    134
- Permanent resident population         Abroad     38
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad    238
- Permanent resident population         Abroad   8660
- Permanent resident population         Abroad     67
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad     57
- Permanent resident population         Abroad    662
- Permanent resident population         Abroad    429
- Permanent resident population         Abroad    970
- Permanent resident population         Abroad    210
- Permanent resident population         Abroad   4134
- Permanent resident population         Abroad    120
- Permanent resident population         Abroad     81
- Permanent resident population         Abroad    281
- Permanent resident population         Abroad    282
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad    294
- Permanent resident population         Abroad   1559
- Permanent resident population         Abroad   1610
- Permanent resident population         Abroad  10253
- Permanent resident population         Abroad    324
- Permanent resident population         Abroad   4358
- Permanent resident population         Abroad    125
- Permanent resident population         Abroad    344
- Permanent resident population         Abroad   1368
- Permanent resident population         Abroad    110
- Permanent resident population         Abroad     76
- Permanent resident population         Abroad   1580
- Permanent resident population         Abroad     56
- Permanent resident population         Abroad    802
- Permanent resident population         Abroad     21
- Permanent resident population         Abroad    100
- Permanent resident population         Abroad    649
- Permanent resident population         Abroad    207
- Permanent resident population         Abroad    865
- Permanent resident population         Abroad    834
- Permanent resident population         Abroad    129
- Permanent resident population         Abroad    116
- Permanent resident population         Abroad    317
- Permanent resident population         Abroad     79
- Permanent resident population         Abroad     55
- Permanent resident population         Abroad    136
- Permanent resident population         Abroad    423
- Permanent resident population         Abroad    244
- Permanent resident population         Abroad     66
- Permanent resident population         Abroad    585
- Permanent resident population         Abroad    722
- Permanent resident population         Abroad    164
- Permanent resident population         Abroad    298
- Permanent resident population         Abroad     64
- Permanent resident population         Abroad    427
- Permanent resident population         Abroad     62
- Permanent resident population         Abroad     25
- Permanent resident population         Abroad    539
- Permanent resident population         Abroad     31
- Permanent resident population         Abroad    183
- Permanent resident population         Abroad    516
- Permanent resident population         Abroad   1630
- Permanent resident population         Abroad    866
- Permanent resident population         Abroad    121
- Permanent resident population         Abroad    496
- Permanent resident population         Abroad   9852
- Permanent resident population         Abroad    298
- Permanent resident population         Abroad   1137
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad   6166
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad    120
- Permanent resident population         Abroad    106
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad    195
- Permanent resident population         Abroad     48
- Permanent resident population         Abroad   1248
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad    381
- Permanent resident population         Abroad   1616
- Permanent resident population         Abroad   5431
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad    526
- Permanent resident population         Abroad     62
- Permanent resident population         Abroad    443
- Permanent resident population         Abroad    220
- Permanent resident population         Abroad    137
- Permanent resident population         Abroad      8
- Permanent resident population         Abroad     28
- Permanent resident population         Abroad     12
- Permanent resident population         Abroad   2571
- Permanent resident population         Abroad    132
- Permanent resident population         Abroad     58
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad    108
- Permanent resident population         Abroad    835
- Permanent resident population         Abroad   1118
- Permanent resident population         Abroad     98
- Permanent resident population         Abroad   8127
- Permanent resident population         Abroad    568
- Permanent resident population         Abroad     22
- Permanent resident population         Abroad    900
- Permanent resident population         Abroad    211
- Permanent resident population         Abroad    281
- Permanent resident population         Abroad   1005
- Permanent resident population         Abroad    432
- Permanent resident population         Abroad    340
- Permanent resident population         Abroad    195
- Permanent resident population         Abroad    289
- Permanent resident population         Abroad    395
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad    122
- Permanent resident population         Abroad   6344
- Permanent resident population         Abroad    312
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad   2378
- Permanent resident population         Abroad    147
- Permanent resident population         Abroad     56
- Permanent resident population         Abroad    416
- Permanent resident population         Abroad    150
- Permanent resident population         Abroad   4306
- Permanent resident population         Abroad   1116
- Permanent resident population         Abroad    564
- Permanent resident population         Abroad   1282
- Permanent resident population         Abroad    341
- Permanent resident population         Abroad    136
- Permanent resident population         Abroad     42
- Permanent resident population         Abroad    979
- Permanent resident population         Abroad     97
- Permanent resident population         Abroad     23
- Permanent resident population         Abroad    214
- Permanent resident population         Abroad   1562
- Permanent resident population         Abroad    128
- Permanent resident population         Abroad    168
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad    175
- Permanent resident population         Abroad    100
- Permanent resident population         Abroad   6265
- Permanent resident population         Abroad    480
- Permanent resident population         Abroad    968
- Permanent resident population         Abroad   2627
- Permanent resident population         Abroad     59
- Permanent resident population         Abroad   1569
- Permanent resident population         Abroad    330
- Permanent resident population         Abroad     38
- Permanent resident population         Abroad   1991
- Permanent resident population         Abroad  11800
- Permanent resident population         Abroad    300
- Permanent resident population         Abroad   1170
- Permanent resident population         Abroad    902
- Permanent resident population         Abroad     70
- Permanent resident population         Abroad    989
- Permanent resident population         Abroad    831
- Permanent resident population         Abroad    373
- Permanent resident population         Abroad    529
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad     85
- Permanent resident population         Abroad     81
- Permanent resident population         Abroad    171
- Permanent resident population         Abroad    131
- Permanent resident population         Abroad    300
- Permanent resident population         Abroad    112
- Permanent resident population         Abroad    229
- Permanent resident population         Abroad    499
- Permanent resident population         Abroad    218
- Permanent resident population         Abroad    376
- Permanent resident population         Abroad    982
- Permanent resident population         Abroad     39
- Permanent resident population         Abroad     34
- Permanent resident population         Abroad    118
- Permanent resident population         Abroad    107
- Permanent resident population         Abroad    708
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad   8828
- Permanent resident population         Abroad     75
- Permanent resident population         Abroad    846
- Permanent resident population         Abroad    310
- Permanent resident population         Abroad   1082
- Permanent resident population         Abroad   1119
- Permanent resident population         Abroad    318
- Permanent resident population         Abroad     41
- Permanent resident population         Abroad     44
- Permanent resident population         Abroad    243
- Permanent resident population         Abroad    116
- Permanent resident population         Abroad    455
- Permanent resident population         Abroad   7795
- Permanent resident population         Abroad    215
- Permanent resident population         Abroad    190
- Permanent resident population         Abroad    181
- Permanent resident population         Abroad    328
- Permanent resident population         Abroad     45
- Permanent resident population         Abroad     19
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad     42
- Permanent resident population         Abroad    974
- Permanent resident population         Abroad    396
- Permanent resident population         Abroad    108
- Permanent resident population         Abroad    330
- Permanent resident population         Abroad   1044
- Permanent resident population         Abroad   1573
- Permanent resident population         Abroad    827
- Permanent resident population         Abroad    501
- Permanent resident population         Abroad   1817
- Permanent resident population         Abroad    143
- Permanent resident population         Abroad     85
- Permanent resident population         Abroad   1422
- Permanent resident population         Abroad    277
- Permanent resident population         Abroad    325
- Permanent resident population         Abroad   8363
- Permanent resident population         Abroad     79
- Permanent resident population         Abroad    406
- Permanent resident population         Abroad   1017
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad    821
- Permanent resident population         Abroad   1468
- Permanent resident population         Abroad    215
- Permanent resident population         Abroad     23
- Permanent resident population         Abroad   1002
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad   5256
- Permanent resident population         Abroad    127
- Permanent resident population         Abroad    656
- Permanent resident population         Abroad   4402
- Permanent resident population         Abroad    553
- Permanent resident population         Abroad    719
- Permanent resident population         Abroad   1372
- Permanent resident population         Abroad     75
- Permanent resident population         Abroad    418
- Permanent resident population         Abroad     76
- Permanent resident population         Abroad    698
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad    142
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad     60
- Permanent resident population         Abroad    244
- Permanent resident population         Abroad    366
- Permanent resident population         Abroad   3168
- Permanent resident population         Abroad    287
- Permanent resident population         Abroad  21463
- Permanent resident population         Abroad     47
- Permanent resident population         Abroad    234
- Permanent resident population         Abroad    557
- Permanent resident population         Abroad   3654
- Permanent resident population         Abroad     64
- Permanent resident population         Abroad     86
- Permanent resident population         Abroad    312
- Permanent resident population         Abroad     84
- Permanent resident population         Abroad    303
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad   1678
- Permanent resident population         Abroad    375
- Permanent resident population         Abroad     12
- Permanent resident population         Abroad    638
- Permanent resident population         Abroad    105
- Permanent resident population         Abroad    187
- Permanent resident population         Abroad    773
- Permanent resident population         Abroad    128
- Permanent resident population         Abroad   1357
- Permanent resident population         Abroad    248
- Permanent resident population         Abroad    322
- Permanent resident population         Abroad    106
- Permanent resident population         Abroad    274
- Permanent resident population         Abroad    302
- Permanent resident population         Abroad   4213
- Permanent resident population         Abroad     77
- Permanent resident population         Abroad    721
- Permanent resident population         Abroad    111
- Permanent resident population         Abroad     58
- Permanent resident population         Abroad    164
- Permanent resident population         Abroad      9
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad     14
- Permanent resident population         Abroad    550
- Permanent resident population         Abroad     40
- Permanent resident population         Abroad    168
- Permanent resident population         Abroad    425
- Permanent resident population         Abroad    205
- Permanent resident population         Abroad   3444
- Permanent resident population         Abroad   1536
- Permanent resident population         Abroad    331
- Permanent resident population         Abroad     26
- Permanent resident population         Abroad    131
- Permanent resident population         Abroad    255
- Permanent resident population         Abroad    172
- Permanent resident population         Abroad     85
- Permanent resident population         Abroad     26
- Permanent resident population         Abroad    244
- Permanent resident population         Abroad   2854
- Permanent resident population         Abroad    344
- Permanent resident population         Abroad    531
- Permanent resident population         Abroad    188
- Permanent resident population         Abroad    764
- Permanent resident population         Abroad    555
- Permanent resident population         Abroad   2007
- Permanent resident population         Abroad    493
- Permanent resident population         Abroad    104
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad    244
- Permanent resident population         Abroad     44
- Permanent resident population         Abroad     16
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad   3090
- Permanent resident population         Abroad     57
- Permanent resident population         Abroad    196
- Permanent resident population         Abroad   1565
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad     16
- Permanent resident population         Abroad    252
- Permanent resident population         Abroad    132
- Permanent resident population         Abroad   1302
- Permanent resident population         Abroad     67
- Permanent resident population         Abroad    449
- Permanent resident population         Abroad    313
- Permanent resident population         Abroad     54
- Permanent resident population         Abroad     74
- Permanent resident population         Abroad     94
- Permanent resident population         Abroad     56
- Permanent resident population         Abroad    240
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad   4600
- Permanent resident population         Abroad    479
- Permanent resident population         Abroad     64
- Permanent resident population         Abroad    488
- Permanent resident population         Abroad    191
- Permanent resident population         Abroad     25
- Permanent resident population         Abroad    396
- Permanent resident population         Abroad   3870
- Permanent resident population         Abroad    214
- Permanent resident population         Abroad   2423
- Permanent resident population         Abroad   4455
- Permanent resident population         Abroad    331
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad   1241
- Permanent resident population         Abroad    438
- Permanent resident population         Abroad     99
- Permanent resident population         Abroad    356
- Permanent resident population         Abroad   5224
- Permanent resident population         Abroad    480
- Permanent resident population         Abroad    210
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad    189
- Permanent resident population         Abroad    160
- Permanent resident population         Abroad   2104
- Permanent resident population         Abroad   6108
- Permanent resident population         Abroad   5980
- Permanent resident population         Abroad    271
- Permanent resident population         Abroad    145
- Permanent resident population         Abroad   2239
- Permanent resident population         Abroad  11853
- Permanent resident population         Abroad    444
- Permanent resident population         Abroad    388
- Permanent resident population         Abroad    106
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad    309
- Permanent resident population         Abroad    453
- Permanent resident population         Abroad   5917
- Permanent resident population         Abroad    129
- Permanent resident population         Abroad    814
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad    814
- Permanent resident population         Abroad    441
- Permanent resident population         Abroad   1650
- Permanent resident population         Abroad    205
- Permanent resident population         Abroad     68
- Permanent resident population         Abroad    165
- Permanent resident population         Abroad     31
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad    245
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad   1778
- Permanent resident population         Abroad     61
- Permanent resident population         Abroad    233
- Permanent resident population         Abroad    265
- Permanent resident population         Abroad    210
- Permanent resident population         Abroad     40
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad   2876
- Permanent resident population         Abroad    521
- Permanent resident population         Abroad    219
- Permanent resident population         Abroad    820
- Permanent resident population         Abroad    884
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad     79
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad     68
- Permanent resident population         Abroad    524
- Permanent resident population         Abroad     89
- Permanent resident population         Abroad    705
- Permanent resident population         Abroad    950
- Permanent resident population         Abroad    608
- Permanent resident population         Abroad    149
- Permanent resident population         Abroad    392
- Permanent resident population         Abroad    189
- Permanent resident population         Abroad    416
- Permanent resident population         Abroad    509
- Permanent resident population         Abroad     78
- Permanent resident population         Abroad    792
- Permanent resident population         Abroad   1939
- Permanent resident population         Abroad    938
- Permanent resident population         Abroad     76
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad    344
- Permanent resident population         Abroad    266
- Permanent resident population         Abroad   2364
- Permanent resident population         Abroad   1946
- Permanent resident population         Abroad     38
- Permanent resident population         Abroad     15
- Permanent resident population         Abroad     80
- Permanent resident population         Abroad    243
- Permanent resident population         Abroad    312
- Permanent resident population         Abroad     86
- Permanent resident population         Abroad    871
- Permanent resident population         Abroad    110
- Permanent resident population         Abroad   1487
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad    516
- Permanent resident population         Abroad    865
- Permanent resident population         Abroad    485
- Permanent resident population         Abroad     15
- Permanent resident population         Abroad   1039
- Permanent resident population         Abroad    504
- Permanent resident population         Abroad    204
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad    136
- Permanent resident population         Abroad     82
- Permanent resident population         Abroad     52
- Permanent resident population         Abroad    814
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad     47
- Permanent resident population         Abroad     37
- Permanent resident population         Abroad    113
- Permanent resident population         Abroad    394
- Permanent resident population         Abroad    144
- Permanent resident population         Abroad   1444
- Permanent resident population         Abroad    122
- Permanent resident population         Abroad    196
- Permanent resident population         Abroad     89
- Permanent resident population         Abroad     59
- Permanent resident population         Abroad     62
- Permanent resident population         Abroad     15
- Permanent resident population         Abroad   2338
- Permanent resident population         Abroad    985
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad    186
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad     73
- Permanent resident population         Abroad    151
- Permanent resident population         Abroad   2858
- Permanent resident population         Abroad    236
- Permanent resident population         Abroad   3346
- Permanent resident population         Abroad    215
- Permanent resident population         Abroad    534
- Permanent resident population         Abroad    369
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad    399
- Permanent resident population         Abroad     23
- Permanent resident population         Abroad    100
- Permanent resident population         Abroad    302
- Permanent resident population         Abroad    498
- Permanent resident population         Abroad    327
- Permanent resident population         Abroad   4995
- Permanent resident population         Abroad   2127
- Permanent resident population         Abroad   1905
- Permanent resident population         Abroad   1694
- Permanent resident population         Abroad    510
- Permanent resident population         Abroad     48
- Permanent resident population         Abroad    162
- Permanent resident population         Abroad    243
- Permanent resident population         Abroad   6722
- Permanent resident population         Abroad      5
- Permanent resident population         Abroad    117
- Permanent resident population         Abroad    283
- Permanent resident population         Abroad   2192
- Permanent resident population         Abroad     92
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad     42
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad    685
- Permanent resident population         Abroad     78
- Permanent resident population         Abroad     98
- Permanent resident population         Abroad    948
- Permanent resident population         Abroad    265
- Permanent resident population         Abroad     96
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad    494
- Permanent resident population         Abroad    236
- Permanent resident population         Abroad     15
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad     45
- Permanent resident population         Abroad     97
- Permanent resident population         Abroad    140
- Permanent resident population         Abroad   1504
- Permanent resident population         Abroad   7560
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad    460
- Permanent resident population         Abroad     74
- Permanent resident population         Abroad     82
- Permanent resident population         Abroad    213
- Permanent resident population         Abroad   3120
- Permanent resident population         Abroad     41
- Permanent resident population         Abroad     12
- Permanent resident population         Abroad    238
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad     11
- Permanent resident population         Abroad    836
- Permanent resident population         Abroad    472
- Permanent resident population         Abroad    598
- Permanent resident population         Abroad    255
- Permanent resident population         Abroad    212
- Permanent resident population         Abroad    171
- Permanent resident population         Abroad   1742
- Permanent resident population         Abroad    436
- Permanent resident population         Abroad     25
- Permanent resident population         Abroad    764
- Permanent resident population         Abroad    847
- Permanent resident population         Abroad    961
- Permanent resident population         Abroad    592
- Permanent resident population         Abroad    146
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad    302
- Permanent resident population         Abroad   1788
- Permanent resident population         Abroad    321
- Permanent resident population         Abroad   2567
- Permanent resident population         Abroad    400
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad    286
- Permanent resident population         Abroad     31
- Permanent resident population         Abroad   3378
- Permanent resident population         Abroad   1009
- Permanent resident population         Abroad     80
- Permanent resident population         Abroad    355
- Permanent resident population         Abroad    102
- Permanent resident population         Abroad   2177
- Permanent resident population         Abroad    130
- Permanent resident population         Abroad     72
- Permanent resident population         Abroad    956
- Permanent resident population         Abroad    205
- Permanent resident population         Abroad    189
- Permanent resident population         Abroad    109
- Permanent resident population         Abroad    328
- Permanent resident population         Abroad    208
- Permanent resident population         Abroad    866
- Permanent resident population         Abroad   2013
- Permanent resident population         Abroad    117
- Permanent resident population         Abroad    379
- Permanent resident population         Abroad    244
- Permanent resident population         Abroad   1065
- Permanent resident population         Abroad    159
- Permanent resident population         Abroad     19
- Permanent resident population         Abroad    148
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad     74
- Permanent resident population         Abroad     22
- Permanent resident population         Abroad   3606
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad   7750
- Permanent resident population         Abroad    239
- Permanent resident population         Abroad     65
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad    166
- Permanent resident population         Abroad    140
- Permanent resident population         Abroad     42
- Permanent resident population         Abroad   2332
- Permanent resident population         Abroad  15316
- Permanent resident population         Abroad   1239
- Permanent resident population         Abroad   4288
- Permanent resident population         Abroad    848
- Permanent resident population         Abroad    304
- Permanent resident population         Abroad     99
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad    201
- Permanent resident population         Abroad   2284
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad    115
- Permanent resident population         Abroad  10085
- Permanent resident population         Abroad    268
- Permanent resident population         Abroad    118
- Permanent resident population         Abroad    307
- Permanent resident population         Abroad      5
- Permanent resident population         Abroad    111
- Permanent resident population         Abroad    444
- Permanent resident population         Abroad     25
- Permanent resident population         Abroad      9
- Permanent resident population         Abroad    329
- Permanent resident population         Abroad    123
- Permanent resident population         Abroad     40
- Permanent resident population         Abroad    454
- Permanent resident population         Abroad   1385
- Permanent resident population         Abroad    101
- Permanent resident population         Abroad    129
- Permanent resident population         Abroad    408
- Permanent resident population         Abroad   1863
- Permanent resident population         Abroad   1472
- Permanent resident population         Abroad    321
- Permanent resident population         Abroad     14
- Permanent resident population         Abroad   2335
- Permanent resident population         Abroad    176
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad     45
- Permanent resident population         Abroad   1538
- Permanent resident population         Abroad    153
- Permanent resident population         Abroad    122
- Permanent resident population         Abroad   3940
- Permanent resident population         Abroad   1205
- Permanent resident population         Abroad    988
- Permanent resident population         Abroad    119
- Permanent resident population         Abroad    225
- Permanent resident population         Abroad   1359
- Permanent resident population         Abroad     16
- Permanent resident population         Abroad    104
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad   3354
- Permanent resident population         Abroad    328
- Permanent resident population         Abroad    873
- Permanent resident population         Abroad    306
- Permanent resident population         Abroad    772
- Permanent resident population         Abroad   1462
- Permanent resident population         Abroad   3200
- Permanent resident population         Abroad     70
- Permanent resident population         Abroad   1314
- Permanent resident population         Abroad    631
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad    417
- Permanent resident population         Abroad   2289
- Permanent resident population         Abroad    673
- Permanent resident population         Abroad    342
- Permanent resident population         Abroad     97
- Permanent resident population         Abroad     28
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad     93
- Permanent resident population         Abroad    447
- Permanent resident population         Abroad    514
- Permanent resident population         Abroad    518
- Permanent resident population         Abroad   1518
- Permanent resident population         Abroad    188
- Permanent resident population         Abroad    911
- Permanent resident population         Abroad    211
- Permanent resident population         Abroad    223
- Permanent resident population         Abroad    570
- Permanent resident population         Abroad    611
- Permanent resident population         Abroad    760
- Permanent resident population         Abroad    263
- Permanent resident population         Abroad     14
- Permanent resident population         Abroad    703
- Permanent resident population         Abroad    238
- Permanent resident population         Abroad    295
- Permanent resident population         Abroad   3017
- Permanent resident population         Abroad    130
- Permanent resident population         Abroad    349
- Permanent resident population         Abroad    990
- Permanent resident population         Abroad    170
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad    235
- Permanent resident population         Abroad    199
- Permanent resident population         Abroad      3
- Permanent resident population         Abroad   7286
- Permanent resident population         Abroad    877
- Permanent resident population         Abroad    802
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad    152
- Permanent resident population         Abroad    263
- Permanent resident population         Abroad   1700
- Permanent resident population         Abroad    201
- Permanent resident population         Abroad    141
- Permanent resident population         Abroad    382
- Permanent resident population         Abroad    370
- Permanent resident population         Abroad    490
- Permanent resident population         Abroad    293
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad    221
- Permanent resident population         Abroad    793
- Permanent resident population         Abroad     29
- Permanent resident population         Abroad   3176
- Permanent resident population         Abroad    202
- Permanent resident population         Abroad     91
- Permanent resident population         Abroad    337
- Permanent resident population         Abroad    188
- Permanent resident population         Abroad    219
- Permanent resident population         Abroad      6
- Permanent resident population         Abroad      8
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad    649
- Permanent resident population         Abroad    302
- Permanent resident population         Abroad    416
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad    256
- Permanent resident population         Abroad    139
- Permanent resident population         Abroad   1456
- Permanent resident population         Abroad   2008
- Permanent resident population         Abroad   1296
- Permanent resident population         Abroad    332
- Permanent resident population         Abroad    122
- Permanent resident population         Abroad   1708
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad     11
- Permanent resident population         Abroad   1961
- Permanent resident population         Abroad   1297
- Permanent resident population         Abroad    193
- Permanent resident population         Abroad     79
- Permanent resident population         Abroad    146
- Permanent resident population         Abroad     58
- Permanent resident population         Abroad   1472
- Permanent resident population         Abroad    327
- Permanent resident population         Abroad    148
- Permanent resident population         Abroad    215
- Permanent resident population         Abroad    273
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad   1150
- Permanent resident population         Abroad     48
- Permanent resident population         Abroad    794
- Permanent resident population         Abroad   3463
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad    104
- Permanent resident population         Abroad     42
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad      4
- Permanent resident population         Abroad    222
- Permanent resident population         Abroad    233
- Permanent resident population         Abroad   2103
- Permanent resident population         Abroad    505
- Permanent resident population         Abroad     61
- Permanent resident population         Abroad     74
- Permanent resident population         Abroad     62
- Permanent resident population         Abroad     60
- Permanent resident population         Abroad    104
- Permanent resident population         Abroad   1305
- Permanent resident population         Abroad    897
- Permanent resident population         Abroad    107
- Permanent resident population         Abroad    151
- Permanent resident population         Abroad    626
- Permanent resident population         Abroad      8
- Permanent resident population         Abroad      3
- Permanent resident population         Abroad    596
- Permanent resident population         Abroad    103
- Permanent resident population         Abroad   1360
- Permanent resident population         Abroad    162
- Permanent resident population         Abroad    191
- Permanent resident population         Abroad     70
- Permanent resident population         Abroad    164
- Permanent resident population         Abroad    609
- Permanent resident population         Abroad    284
- Permanent resident population         Abroad    130
- Permanent resident population         Abroad   1446
- Permanent resident population         Abroad   1040
- Permanent resident population         Abroad   1084
- Permanent resident population         Abroad    376
- Permanent resident population         Abroad    200
- Permanent resident population         Abroad    165
- Permanent resident population         Abroad   3675
- Permanent resident population         Abroad    224
- Permanent resident population         Abroad    429
- Permanent resident population         Abroad    140
- Permanent resident population         Abroad   3733
- Permanent resident population         Abroad    700
- Permanent resident population         Abroad   1138
- Permanent resident population         Abroad     49
- Permanent resident population         Abroad   3505
- Permanent resident population         Abroad    300
- Permanent resident population         Abroad     54
- Permanent resident population         Abroad    971
- Permanent resident population         Abroad     82
- Permanent resident population         Abroad    616
- Permanent resident population         Abroad     26
- Permanent resident population         Abroad     88
- Permanent resident population         Abroad    598
- Permanent resident population         Abroad    224
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad    445
- Permanent resident population         Abroad     25
- Permanent resident population         Abroad    126
- Permanent resident population         Abroad    826
- Permanent resident population         Abroad    147
- Permanent resident population         Abroad   1172
- Permanent resident population         Abroad   1563
- Permanent resident population         Abroad    585
- Permanent resident population         Abroad    231
- Permanent resident population         Abroad     73
- Permanent resident population         Abroad    813
- Permanent resident population         Abroad     19
- Permanent resident population         Abroad    397
- Permanent resident population         Abroad    191
- Permanent resident population         Abroad     13
- Permanent resident population         Abroad    173
- Permanent resident population         Abroad    156
- Permanent resident population         Abroad     73
- Permanent resident population         Abroad    171
- Permanent resident population         Abroad    171
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad     62
- Permanent resident population         Abroad    834
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad    304
- Permanent resident population         Abroad     77
- Permanent resident population         Abroad     14
- Permanent resident population         Abroad    141
- Permanent resident population         Abroad   1887
- Permanent resident population         Abroad   5714
- Permanent resident population         Abroad    100
- Permanent resident population         Abroad   1347
- Permanent resident population         Abroad    178
- Permanent resident population         Abroad    764
- Permanent resident population         Abroad    228
- Permanent resident population         Abroad   3531
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad    367
- Permanent resident population         Abroad    293
- Permanent resident population         Abroad    188
- Permanent resident population         Abroad    741
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad    190
- Permanent resident population         Abroad     45
- Permanent resident population         Abroad    146
- Permanent resident population         Abroad   2092
- Permanent resident population         Abroad    171
- Permanent resident population         Abroad     34
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad    503
- Permanent resident population         Abroad    533
- Permanent resident population         Abroad    483
- Permanent resident population         Abroad    651
- Permanent resident population         Abroad    276
- Permanent resident population         Abroad   2641
- Permanent resident population         Abroad    527
- Permanent resident population         Abroad    258
- Permanent resident population         Abroad   1893
- Permanent resident population         Abroad     68
- Permanent resident population         Abroad     66
- Permanent resident population         Abroad    126
- Permanent resident population         Abroad     77
- Permanent resident population         Abroad   1853
- Permanent resident population         Abroad    197
- Permanent resident population         Abroad    267
- Permanent resident population         Abroad    249
- Permanent resident population         Abroad      6
- Permanent resident population         Abroad     56
- Permanent resident population         Abroad    358
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad    289
- Permanent resident population         Abroad    163
- Permanent resident population         Abroad    124
- Permanent resident population         Abroad    518
- Permanent resident population         Abroad    186
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad     93
- Permanent resident population         Abroad    225
- Permanent resident population         Abroad   2261
- Permanent resident population         Abroad   1658
- Permanent resident population         Abroad    209
- Permanent resident population         Abroad    269
- Permanent resident population         Abroad    371
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad     75
- Permanent resident population         Abroad    132
- Permanent resident population         Abroad    444
- Permanent resident population         Abroad     19
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad    370
- Permanent resident population         Abroad     29
- Permanent resident population         Abroad   2627
- Permanent resident population         Abroad   1052
- Permanent resident population         Abroad   2271
- Permanent resident population         Abroad    288
- Permanent resident population         Abroad     26
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad   1237
- Permanent resident population         Abroad   2409
- Permanent resident population         Abroad   1128
- Permanent resident population         Abroad    210
- Permanent resident population         Abroad    380
- Permanent resident population         Abroad    214
- Permanent resident population         Abroad     56
- Permanent resident population         Abroad    166
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad    399
- Permanent resident population         Abroad    163
- Permanent resident population         Abroad    101
- Permanent resident population         Abroad      6
- Permanent resident population         Abroad     80
- Permanent resident population         Abroad   3499
- Permanent resident population         Abroad   1123
- Permanent resident population         Abroad    115
- Permanent resident population         Abroad    138
- Permanent resident population         Abroad     85
- Permanent resident population         Abroad    628
- Permanent resident population         Abroad     48
- Permanent resident population         Abroad     42
- Permanent resident population         Abroad    410
- Permanent resident population         Abroad    142
- Permanent resident population         Abroad   2015
- Permanent resident population         Abroad     92
- Permanent resident population         Abroad    281
- Permanent resident population         Abroad     56
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad    593
- Permanent resident population         Abroad    124
- Permanent resident population         Abroad     82
- Permanent resident population         Abroad   1241
- Permanent resident population         Abroad    576
- Permanent resident population         Abroad    309
- Permanent resident population         Abroad    460
- Permanent resident population         Abroad    249
- Permanent resident population         Abroad    440
- Permanent resident population         Abroad    355
- Permanent resident population         Abroad     88
- Permanent resident population         Abroad    563
- Permanent resident population         Abroad    476
- Permanent resident population         Abroad    631
- Permanent resident population         Abroad   4323
- Permanent resident population         Abroad    219
- Permanent resident population         Abroad   5740
- Permanent resident population         Abroad     99
- Permanent resident population         Abroad    844
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad     95
- Permanent resident population         Abroad    543
- Permanent resident population         Abroad    224
- Permanent resident population         Abroad    221
- Permanent resident population         Abroad    474
- Permanent resident population         Abroad    157
- Permanent resident population         Abroad    294
- Permanent resident population         Abroad    819
- Permanent resident population         Abroad   2558
- Permanent resident population         Abroad    253
- Permanent resident population         Abroad    600
- Permanent resident population         Abroad     98
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad    676
- Permanent resident population         Abroad    284
- Permanent resident population         Abroad    225
- Permanent resident population         Abroad    495
- Permanent resident population         Abroad     39
- Permanent resident population         Abroad   2782
- Permanent resident population         Abroad    198
- Permanent resident population         Abroad    395
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad    328
- Permanent resident population         Abroad      6
- Permanent resident population         Abroad    241
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad    593
- Permanent resident population         Abroad    343
- Permanent resident population         Abroad    194
- Permanent resident population         Abroad    127
- Permanent resident population         Abroad     58
- Permanent resident population         Abroad     23
- Permanent resident population         Abroad    880
- Permanent resident population         Abroad      4
- Permanent resident population         Abroad    700
- Permanent resident population         Abroad    136
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad    624
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad   1693
- Permanent resident population         Abroad     50
- Permanent resident population         Abroad    178
- Permanent resident population         Abroad    214
- Permanent resident population         Abroad   3190
- Permanent resident population         Abroad    425
- Permanent resident population         Abroad     96
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad    259
- Permanent resident population         Abroad   8624
- Permanent resident population         Abroad     84
- Permanent resident population         Abroad    129
- Permanent resident population         Abroad     66
- Permanent resident population         Abroad    124
- Permanent resident population         Abroad   1100
- Permanent resident population         Abroad    137
- Permanent resident population         Abroad    235
- Permanent resident population         Abroad   1211
- Permanent resident population         Abroad   6378
- Permanent resident population         Abroad    144
- Permanent resident population         Abroad    266
- Permanent resident population         Abroad    879
- Permanent resident population         Abroad    438
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad     98
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad     28
- Permanent resident population         Abroad   2353
- Permanent resident population         Abroad    491
- Permanent resident population         Abroad    111
- Permanent resident population         Abroad    423
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad     96
- Permanent resident population         Abroad    130
- Permanent resident population         Abroad    258
- Permanent resident population         Abroad    186
- Permanent resident population         Abroad     57
- Permanent resident population         Abroad    187
- Permanent resident population         Abroad    499
- Permanent resident population         Abroad    821
- Permanent resident population         Abroad    407
- Permanent resident population         Abroad    189
- Permanent resident population         Abroad     21
- Permanent resident population         Abroad    115
- Permanent resident population         Abroad     16
- Permanent resident population         Abroad    548
- Permanent resident population         Abroad    415
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad     15
- Permanent resident population         Abroad   3296
- Permanent resident population         Abroad    149
- Permanent resident population         Abroad   1148
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad     93
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad   1268
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad    858
- Permanent resident population         Abroad    255
- Permanent resident population         Abroad  26724
- Permanent resident population         Abroad    672
- Permanent resident population         Abroad   3625
- Permanent resident population         Abroad   1065
- Permanent resident population         Abroad    188
- Permanent resident population         Abroad     77
- Permanent resident population         Abroad    339
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad    190
- Permanent resident population         Abroad    243
- Permanent resident population         Abroad    104
- Permanent resident population         Abroad    218
- Permanent resident population         Abroad     26
- Permanent resident population         Abroad    318
- Permanent resident population         Abroad     17
- Permanent resident population         Abroad     59
- Permanent resident population         Abroad    132
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad    256
- Permanent resident population         Abroad    248
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad     50
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad   1126
- Permanent resident population         Abroad   1287
- Permanent resident population         Abroad    822
- Permanent resident population         Abroad    794
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad    660
- Permanent resident population         Abroad    473
- Permanent resident population         Abroad    602
- Permanent resident population         Abroad   4425
- Permanent resident population         Abroad  34670
- Permanent resident population         Abroad    631
- Permanent resident population         Abroad    923
- Permanent resident population         Abroad   5064
- Permanent resident population         Abroad     48
- Permanent resident population         Abroad  56496
- Permanent resident population         Abroad    318
- Permanent resident population         Abroad   1899
- Permanent resident population         Abroad    444
- Permanent resident population         Abroad    226
- Permanent resident population         Abroad    436
- Permanent resident population         Abroad     55
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad    774
- Permanent resident population         Abroad    106
- Permanent resident population         Abroad    140
- Permanent resident population         Abroad    479
- Permanent resident population         Abroad    424
- Permanent resident population         Abroad   2027
- Permanent resident population         Abroad    146
- Permanent resident population         Abroad    108
- Permanent resident population         Abroad    267
- Permanent resident population         Abroad    876
- Permanent resident population         Abroad    961
- Permanent resident population         Abroad     70
- Permanent resident population         Abroad    162
- Permanent resident population         Abroad     87
- Permanent resident population         Abroad     86
- Permanent resident population         Abroad     11
- Permanent resident population         Abroad    132
- Permanent resident population         Abroad    814
- Permanent resident population         Abroad   1432
- Permanent resident population         Abroad    103
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad   1185
- Permanent resident population         Abroad    218
- Permanent resident population         Abroad   2220
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad    632
- Permanent resident population         Abroad    106
- Permanent resident population         Abroad    103
- Permanent resident population         Abroad     51
- Permanent resident population         Abroad    181
- Permanent resident population         Abroad    112
- Permanent resident population         Abroad    218
- Permanent resident population         Abroad     16
- Permanent resident population         Abroad     55
- Permanent resident population         Abroad    127
- Permanent resident population         Abroad     32
- Permanent resident population         Abroad    672
- Permanent resident population         Abroad    793
- Permanent resident population         Abroad    184
- Permanent resident population         Abroad    177
- Permanent resident population         Abroad    710
- Permanent resident population         Abroad    500
- Permanent resident population         Abroad   4900
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad    781
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad    204
- Permanent resident population         Abroad   1878
- Permanent resident population         Abroad     93
- Permanent resident population         Abroad    135
- Permanent resident population         Abroad    114
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad    667
- Permanent resident population         Abroad    508
- Permanent resident population         Abroad     46
- Permanent resident population         Abroad    159
- Permanent resident population         Abroad    409
- Permanent resident population         Abroad   1355
- Permanent resident population         Abroad    204
- Permanent resident population         Abroad    114
- Permanent resident population         Abroad   1708
- Permanent resident population         Abroad   1151
- Permanent resident population         Abroad     85
- Permanent resident population         Abroad    154
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad     22
- Permanent resident population         Abroad    164
- Permanent resident population         Abroad    186
- Permanent resident population         Abroad    253
- Permanent resident population         Abroad   2958
- Permanent resident population         Abroad    139
- Permanent resident population         Abroad    338
- Permanent resident population         Abroad   3317
- Permanent resident population         Abroad    161
- Permanent resident population         Abroad     28
- Permanent resident population         Abroad    267
- Permanent resident population         Abroad    112
- Permanent resident population         Abroad    519
- Permanent resident population         Abroad    411
- Permanent resident population         Abroad    353
- Permanent resident population         Abroad     49
- Permanent resident population         Abroad     49
- Permanent resident population         Abroad    281
- Permanent resident population         Abroad   1551
- Permanent resident population         Abroad     12
- Permanent resident population         Abroad     81
- Permanent resident population         Abroad     89
- Permanent resident population         Abroad     40
- Permanent resident population         Abroad      8
- Permanent resident population         Abroad   2965
- Permanent resident population         Abroad    161
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad    112
- Permanent resident population         Abroad     64
- Permanent resident population         Abroad     14
- Permanent resident population         Abroad     73
- Permanent resident population         Abroad    273
- Permanent resident population         Abroad    983
- Permanent resident population         Abroad    102
- Permanent resident population         Abroad    169
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad    748
- Permanent resident population         Abroad     18
- Permanent resident population         Abroad    207
- Permanent resident population         Abroad    183
- Permanent resident population         Abroad   1554
- Permanent resident population         Abroad     29
- Permanent resident population         Abroad    383
- Permanent resident population         Abroad   6066
- Permanent resident population         Abroad    463
- Permanent resident population         Abroad    456
- Permanent resident population         Abroad   1140
- Permanent resident population         Abroad   1278
- Permanent resident population         Abroad    309
- Permanent resident population         Abroad    239
- Permanent resident population         Abroad   1961
- Permanent resident population         Abroad     43
- Permanent resident population         Abroad    587
- Permanent resident population         Abroad     57
- Permanent resident population         Abroad     98
- Permanent resident population         Abroad     62
- Permanent resident population         Abroad     10
- Permanent resident population         Abroad     47
- Permanent resident population         Abroad    125
- Permanent resident population         Abroad     73
- Permanent resident population         Abroad    239
- Permanent resident population         Abroad     82
- Permanent resident population         Abroad    121
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad    147
- Permanent resident population         Abroad   2611
- Permanent resident population         Abroad    181
- Permanent resident population         Abroad    757
- Permanent resident population         Abroad   5495
- Permanent resident population         Abroad     94
- Permanent resident population         Abroad    127
- Permanent resident population         Abroad   2856
- Permanent resident population         Abroad    387
- Permanent resident population         Abroad     58
- Permanent resident population         Abroad   7584
- Permanent resident population         Abroad   1443
- Permanent resident population         Abroad    181
- Permanent resident population         Abroad   2468
- Permanent resident population         Abroad    155
- Permanent resident population         Abroad   2107
- Permanent resident population         Abroad    133
- Permanent resident population         Abroad    162
- Permanent resident population         Abroad     47
- Permanent resident population         Abroad    237
- Permanent resident population         Abroad   2925
- Permanent resident population         Abroad     74
- Permanent resident population         Abroad    129
- Permanent resident population         Abroad     29
- Permanent resident population         Abroad    206
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad    114
- Permanent resident population         Abroad    202
- Permanent resident population         Abroad    301
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad    328
- Permanent resident population         Abroad    354
- Permanent resident population         Abroad    171
- Permanent resident population         Abroad    868
- Permanent resident population         Abroad   4554
- Permanent resident population         Abroad    133
- Permanent resident population         Abroad   1249
- Permanent resident population         Abroad    130
- Permanent resident population         Abroad     49
- Permanent resident population         Abroad    921
- Permanent resident population         Abroad     22
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad     20
- Permanent resident population         Abroad     80
- Permanent resident population         Abroad  11268
- Permanent resident population         Abroad    124
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad    120
- Permanent resident population         Abroad    409
- Permanent resident population         Abroad   1921
- Permanent resident population         Abroad     63
- Permanent resident population         Abroad    700
- Permanent resident population         Abroad    902
- Permanent resident population         Abroad     59
- Permanent resident population         Abroad    135
- Permanent resident population         Abroad      5
- Permanent resident population         Abroad    565
- Permanent resident population         Abroad    307
- Permanent resident population         Abroad    130
- Permanent resident population         Abroad     98
- Permanent resident population         Abroad   4507
- Permanent resident population         Abroad    114
- Permanent resident population         Abroad    240
- Permanent resident population         Abroad     36
- Permanent resident population         Abroad      3
- Permanent resident population         Abroad    123
- Permanent resident population         Abroad   1224
- Permanent resident population         Abroad   2204
- Permanent resident population         Abroad    625
- Permanent resident population         Abroad   1348
- Permanent resident population         Abroad     93
- Permanent resident population         Abroad    431
- Permanent resident population         Abroad    205
- Permanent resident population         Abroad    343
- Permanent resident population         Abroad   1174
- Permanent resident population         Abroad    455
- Permanent resident population         Abroad    945
- Permanent resident population         Abroad   1551
- Permanent resident population         Abroad     57
- Permanent resident population         Abroad   1122
- Permanent resident population         Abroad    703
- Permanent resident population         Abroad     71
- Permanent resident population         Abroad    487
- Permanent resident population         Abroad   2718
- Permanent resident population         Abroad   6039
- Permanent resident population         Abroad    872
- Permanent resident population         Abroad     52
- Permanent resident population         Abroad   2316
- Permanent resident population         Abroad    550
- Permanent resident population         Abroad    126
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad    364
- Permanent resident population         Abroad   2571
- Permanent resident population         Abroad     35
- Permanent resident population         Abroad    961
- Permanent resident population         Abroad    146
- Permanent resident population         Abroad   3347
- Permanent resident population         Abroad    545
- Permanent resident population         Abroad    566
- Permanent resident population         Abroad     41
- Permanent resident population         Abroad    133
- Permanent resident population         Abroad     30
- Permanent resident population         Abroad    119
- Permanent resident population         Abroad     53
- Permanent resident population         Abroad    387
- Permanent resident population         Abroad    919
- Permanent resident population         Abroad     65
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad   2028
- Permanent resident population         Abroad   1050
- Permanent resident population         Abroad    305
- Permanent resident population         Abroad     11
- Permanent resident population         Abroad    270
- Permanent resident population         Abroad    167
- Permanent resident population         Abroad    785
- Permanent resident population         Abroad    584
- Permanent resident population         Abroad    608
- Permanent resident population         Abroad   2170
- Permanent resident population         Abroad    956
- Permanent resident population         Abroad    436
- Permanent resident population         Abroad   1034
- Permanent resident population         Abroad   6610
- Permanent resident population         Abroad      2
- Permanent resident population         Abroad   4861
- Permanent resident population         Abroad    209
- Permanent resident population         Abroad   2531
- Permanent resident population         Abroad   1191
- Permanent resident population         Abroad   1677
- Permanent resident population         Abroad    756
- Permanent resident population         Abroad    185
- Permanent resident population         Abroad    266
- Permanent resident population         Abroad   8327
- Permanent resident population         Abroad     69
- Permanent resident population         Abroad    306
- Permanent resident population         Abroad    669
- Permanent resident population         Abroad    338
- Permanent resident population         Abroad    191
- Permanent resident population         Abroad    282
- Permanent resident population         Abroad    634
- Permanent resident population         Abroad    141
- Permanent resident population         Abroad    526
- Permanent resident population         Abroad     48
- Permanent resident population         Abroad   2505
- Permanent resident population         Abroad    333
- Permanent resident population         Abroad    999
- Permanent resident population         Abroad    311
- Permanent resident population         Abroad    468
- Permanent resident population         Abroad    214
- Permanent resident population         Abroad      4
- Permanent resident population         Abroad    360
- Permanent resident population         Abroad    554
- Permanent resident population         Abroad   1319
- Permanent resident population         Abroad    149
- Permanent resident population         Abroad    951
- Permanent resident population         Abroad      1
- Permanent resident population         Abroad     80
- Permanent resident population         Abroad      7
- Permanent resident population         Abroad   2997
- Permanent resident population         Abroad    247
- Permanent resident population         Abroad    245
- Permanent resident population         Abroad   2051
- Permanent resident population         Abroad    312
- Permanent resident population         Abroad     16
- Permanent resident population         Abroad     54
- Permanent resident population         Abroad    775
- Permanent resident population         Abroad     33
- Permanent resident population         Abroad     24
- Permanent resident population         Abroad  29729
- Permanent resident population         Abroad    211
- Permanent resident population         Abroad    441
- Permanent resident population         Abroad     27
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad    103
- Permanent resident population         Abroad    200
- Permanent resident population         Abroad    189
- Permanent resident population         Abroad    169
- Permanent resident population         Abroad     81
- Permanent resident population         Abroad    169
- Permanent resident population         Abroad   1491
- Permanent resident population         Abroad     41
- Permanent resident population         Abroad   1346
- Permanent resident population         Abroad     95
- Permanent resident population         Abroad   1086
- Permanent resident population         Abroad    109
- Permanent resident population         Abroad     23
- Permanent resident population         Abroad     22
- Permanent resident population         Abroad    896
- Permanent resident population         Abroad    115
- Permanent resident population         Abroad    402
- Permanent resident population         Abroad     83
- Permanent resident population         Abroad   1541
- Permanent resident population         Abroad    144
- Permanent resident population         Abroad    561
- Permanent resident population         Abroad   4584
- Permanent resident population         Abroad     82
- Permanent resident population         Abroad   1204
- Permanent resident population         Abroad     44
+ year spatialunit_ontology                   name               population_type
+ 2010         Municipality                  Sauge Permanent resident population
+ 2010         Municipality                 Sergey Permanent resident population
+ 2010         Municipality          Cressier (NE) Permanent resident population
+ 2010         Municipality         Full-Reuenthal Permanent resident population
+ 2010         Municipality               Mägenwil Permanent resident population
+ 2010         Municipality             Altstätten Permanent resident population
+ 2010         Municipality                Dachsen Permanent resident population
+ 2010         Municipality        Arzier-Le Muids Permanent resident population
+ 2010         Municipality                 Gsteig Permanent resident population
+ 2010         Municipality          Jorat-Menthue Permanent resident population
+ 2010         Municipality               Brissago Permanent resident population
+ 2010         Municipality         Hauterive (NE) Permanent resident population
+ 2010         Municipality             Vullierens Permanent resident population
+ 2010         Municipality              Curtilles Permanent resident population
+ 2010         Municipality                Bennwil Permanent resident population
+ 2010         Municipality                 Lupfig Permanent resident population
+ 2010         Municipality                 Fiesch Permanent resident population
+ 2010         Municipality                 Uznach Permanent resident population
+ 2010         Municipality            Romont (FR) Permanent resident population
+ 2010         Municipality             Les Enfers Permanent resident population
+ 2010         Municipality                 Falera Permanent resident population
+ 2010         Municipality                Breggia Permanent resident population
+ 2010         Municipality                Aarberg Permanent resident population
+ 2010         Municipality         Arnex-sur-Nyon Permanent resident population
+ 2010         Municipality                  Gimel Permanent resident population
+ 2010         Municipality               Röschenz Permanent resident population
+ 2010         Municipality            Oberhünigen Permanent resident population
+ 2010         Municipality                 Morlon Permanent resident population
+ 2010         Municipality                 Heiden Permanent resident population
+ 2010         Municipality              Rüti (ZH) Permanent resident population
+ 2010         Municipality                  Grono Permanent resident population
+ 2010         Municipality          Thalheim (AG) Permanent resident population
+ 2010         Municipality                 Mühlau Permanent resident population
+ 2010         Municipality            Chêne-Bourg Permanent resident population
+ 2010         Municipality               Schongau Permanent resident population
+ 2010         Municipality               Eptingen Permanent resident population
+ 2010         Municipality      Beinwil (Freiamt) Permanent resident population
+ 2010         Municipality                Aristau Permanent resident population
+ 2010         Municipality                 Aadorf Permanent resident population
+ 2010         Municipality                  Scuol Permanent resident population
+ 2010         Municipality            Derendingen Permanent resident population
+ 2010         Municipality     Muntogna da Schons Permanent resident population
+ 2010         Municipality              Domleschg Permanent resident population
+ 2010         Municipality              Bubendorf Permanent resident population
+ 2010         Municipality         Unterentfelden Permanent resident population
+ 2010         Municipality                 Hallau Permanent resident population
+ 2010         Municipality    Escholzmatt-Marbach Permanent resident population
+ 2010         Municipality              Belprahon Permanent resident population
+ 2010         Municipality                 Urdorf Permanent resident population
+ 2010         Municipality                    Rue Permanent resident population
+ 2010         Municipality              Göschenen Permanent resident population
+ 2010         Municipality                Zäziwil Permanent resident population
+ 2010         Municipality           Grossdietwil Permanent resident population
+ 2010         Municipality   Bichelsee-Balterswil Permanent resident population
+ 2010         Municipality             Miglieglia Permanent resident population
+ 2010         Municipality               Pratteln Permanent resident population
+ 2010         Municipality                  Borex Permanent resident population
+ 2010         Municipality              Novazzano Permanent resident population
+ 2010         Municipality               Aefligen Permanent resident population
+ 2010         Municipality             Roggliswil Permanent resident population
+ 2010         Municipality             Beckenried Permanent resident population
+ 2010         Municipality                Rheinau Permanent resident population
+ 2010         Municipality                 Jaberg Permanent resident population
+ 2010         Municipality       Villars-le-Comte Permanent resident population
+ 2010         Municipality           Strengelbach Permanent resident population
+ 2010         Municipality             Rothenburg Permanent resident population
+ 2010         Municipality                Fideris Permanent resident population
+ 2010         Municipality              Fürstenau Permanent resident population
+ 2010         Municipality           Bischofszell Permanent resident population
+ 2010         Municipality                 Prilly Permanent resident population
+ 2010         Municipality                Bättwil Permanent resident population
+ 2010         Municipality             Gächlingen Permanent resident population
+ 2010         Municipality            Wiedlisbach Permanent resident population
+ 2010         Municipality             Wisen (SO) Permanent resident population
+ 2010         Municipality      Saint-Martin (FR) Permanent resident population
+ 2010         Municipality           Carouge (GE) Permanent resident population
+ 2010         Municipality                 Grancy Permanent resident population
+ 2010         Municipality               Massagno Permanent resident population
+ 2010         Municipality            Hausen (AG) Permanent resident population
+ 2010         Municipality                Hellsau Permanent resident population
+ 2010         Municipality                Uttigen Permanent resident population
+ 2010         Municipality               Valbroye Permanent resident population
+ 2010         Municipality                 Ebikon Permanent resident population
+ 2010         Municipality             Gaiserwald Permanent resident population
+ 2010         Municipality           Roggwil (TG) Permanent resident population
+ 2010         Municipality              Rorschach Permanent resident population
+ 2010         Municipality               Gruyères Permanent resident population
+ 2010         Municipality          Oberriet (SG) Permanent resident population
+ 2010         Municipality                Wolfwil Permanent resident population
+ 2010         Municipality                 Inkwil Permanent resident population
+ 2010         Municipality             Oberhallau Permanent resident population
+ 2010         Municipality         Kirchberg (SG) Permanent resident population
+ 2010         Municipality                  Anwil Permanent resident population
+ 2010         Municipality             Rossinière Permanent resident population
+ 2010         Municipality             Jegenstorf Permanent resident population
+ 2010         Municipality                  Kerns Permanent resident population
+ 2010         Municipality                 Vétroz Permanent resident population
+ 2010         Municipality                Urnäsch Permanent resident population
+ 2010         Municipality          Haut-Intyamon Permanent resident population
+ 2010         Municipality               Evionnaz Permanent resident population
+ 2010         Municipality                Muzzano Permanent resident population
+ 2010         Municipality                Allaman Permanent resident population
+ 2010         Municipality               Bäriswil Permanent resident population
+ 2010         Municipality         Forel (Lavaux) Permanent resident population
+ 2010         Municipality            Schmiedrued Permanent resident population
+ 2010         Municipality      Plateau de Diesse Permanent resident population
+ 2010         Municipality                 Gonten Permanent resident population
+ 2010         Municipality                  Avusy Permanent resident population
+ 2010         Municipality               Hedingen Permanent resident population
+ 2010         Municipality              Plaffeien Permanent resident population
+ 2010         Municipality                  Spiez Permanent resident population
+ 2010         Municipality              Neckertal Permanent resident population
+ 2010         Municipality              Meltingen Permanent resident population
+ 2010         Municipality       La Côte-aux-Fées Permanent resident population
+ 2010         Municipality                 Urmein Permanent resident population
+ 2010         Municipality               Oekingen Permanent resident population
+ 2010         Municipality                 Rorbas Permanent resident population
+ 2010         Municipality                  Agiez Permanent resident population
+ 2010         Municipality               Boltigen Permanent resident population
+ 2010         Municipality                  Realp Permanent resident population
+ 2010         Municipality              Fällanden Permanent resident population
+ 2010         Municipality        Jouxtens-Mézery Permanent resident population
+ 2010         Municipality              Muntelier Permanent resident population
+ 2010         Municipality           Gontenschwil Permanent resident population
+ 2010         Municipality            Schönenbuch Permanent resident population
+ 2010         Municipality   Essertines-sur-Rolle Permanent resident population
+ 2010         Municipality           Bas-Intyamon Permanent resident population
+ 2010         Municipality        Medel (Lucmagn) Permanent resident population
+ 2010         Municipality              Hagenbuch Permanent resident population
+ 2010         Municipality            Corminboeuf Permanent resident population
+ 2010         Municipality       Teuffenthal (BE) Permanent resident population
+ 2010         Municipality            Gsteigwiler Permanent resident population
+ 2010         Municipality           Ebnat-Kappel Permanent resident population
+ 2010         Municipality                 Bülach Permanent resident population
+ 2010         Municipality                  Curio Permanent resident population
+ 2010         Municipality           Oberwil (BL) Permanent resident population
+ 2010         Municipality              Onsernone Permanent resident population
+ 2010         Municipality               Frutigen Permanent resident population
+ 2010         Municipality              Hohenrain Permanent resident population
+ 2010         Municipality      Villars-sur-Glâne Permanent resident population
+ 2010         Municipality                Juriens Permanent resident population
+ 2010         Municipality             Hauteville Permanent resident population
+ 2010         Municipality              Ottenbach Permanent resident population
+ 2010         Municipality               Salgesch Permanent resident population
+ 2010         Municipality             Bourrignon Permanent resident population
+ 2010         Municipality               Reutigen Permanent resident population
+ 2010         Municipality    Kradolf-Schönenberg Permanent resident population
+ 2010         Municipality            Saules (BE) Permanent resident population
+ 2010         Municipality                 Naters Permanent resident population
+ 2010         Municipality              Landquart Permanent resident population
+ 2010         Municipality                  Aarau Permanent resident population
+ 2010         Municipality        Walterswil (SO) Permanent resident population
+ 2010         Municipality          Grandfontaine Permanent resident population
+ 2010         Municipality                 Rances Permanent resident population
+ 2010         Municipality Erlenbach im Simmental Permanent resident population
+ 2010         Municipality               Semsales Permanent resident population
+ 2010         Municipality                 Horgen Permanent resident population
+ 2010         Municipality     Saint-Sulpice (VD) Permanent resident population
+ 2010         Municipality         Le Bémont (JU) Permanent resident population
+ 2010         Municipality            Wölflinswil Permanent resident population
+ 2010         Municipality  La Chaux-des-Breuleux Permanent resident population
+ 2010         Municipality              Anniviers Permanent resident population
+ 2010         Municipality                  Soral Permanent resident population
+ 2010         Municipality           Grandvillard Permanent resident population
+ 2010         Municipality              Innerthal Permanent resident population
+ 2010         Municipality                Origlio Permanent resident population
+ place_of_birth amount
+         Abroad    136
+         Abroad     10
+         Abroad    524
+         Abroad    118
+         Abroad    394
+         Abroad   2425
+         Abroad    345
+         Abroad    782
+         Abroad    142
+         Abroad    202
+         Abroad    528
+         Abroad    822
+         Abroad     63
+         Abroad     46
+         Abroad     38
+         Abroad    544
+         Abroad    209
+         Abroad   1452
+         Abroad   1625
+         Abroad     10
+         Abroad     80
+         Abroad    346
+         Abroad    561
+         Abroad     41
+         Abroad    491
+         Abroad    183
+         Abroad     16
+         Abroad     75
+         Abroad    930
+         Abroad   3260
+         Abroad    325
+         Abroad     51
+         Abroad    115
+         Abroad   3606
+         Abroad     65
+         Abroad     52
+         Abroad    100
+         Abroad    216
+         Abroad   1373
+         Abroad   1193
+         Abroad   1437
+         Abroad     18
+         Abroad    157
+         Abroad    647
+         Abroad    871
+         Abroad    355
+         Abroad    255
+         Abroad     29
+         Abroad   2372
+         Abroad    144
+         Abroad     33
+         Abroad    140
+         Abroad     54
+         Abroad    365
+         Abroad     48
+         Abroad   5579
+         Abroad    303
+         Abroad    609
+         Abroad     76
+         Abroad     25
+         Abroad    381
+         Abroad    329
+         Abroad     13
+         Abroad     15
+         Abroad   1016
+         Abroad    745
+         Abroad     46
+         Abroad     43
+         Abroad   1264
+         Abroad   4655
+         Abroad    230
+         Abroad     93
+         Abroad    359
+         Abroad     30
+         Abroad     99
+         Abroad   8715
+         Abroad     62
+         Abroad   2770
+         Abroad    620
+         Abroad     11
+         Abroad    131
+         Abroad    482
+         Abroad   2963
+         Abroad   1316
+         Abroad    370
+         Abroad   3780
+         Abroad    312
+         Abroad   1234
+         Abroad    156
+         Abroad     54
+         Abroad     41
+         Abroad   1731
+         Abroad     43
+         Abroad     99
+         Abroad    589
+         Abroad    517
+         Abroad   1191
+         Abroad    302
+         Abroad    209
+         Abroad    195
+         Abroad    202
+         Abroad    113
+         Abroad     94
+         Abroad    390
+         Abroad    120
+         Abroad    230
+         Abroad     80
+         Abroad    293
+         Abroad    646
+         Abroad    239
+         Abroad   1549
+         Abroad    429
+         Abroad     43
+         Abroad     67
+         Abroad      7
+         Abroad     56
+         Abroad    625
+         Abroad     32
+         Abroad     69
+         Abroad     10
+         Abroad   2399
+         Abroad    360
+         Abroad    154
+         Abroad    320
+         Abroad    258
+         Abroad    186
+         Abroad    155
+         Abroad     22
+         Abroad    124
+         Abroad    302
+         Abroad      7
+         Abroad     39
+         Abroad    728
+         Abroad   5293
+         Abroad    106
+         Abroad   2682
+         Abroad     94
+         Abroad    545
+         Abroad    194
+         Abroad   3919
+         Abroad     23
+         Abroad     58
+         Abroad    332
+         Abroad    176
+         Abroad     17
+         Abroad     61
+         Abroad    732
+         Abroad      8
+         Abroad   1164
+         Abroad   1775
+         Abroad   4775
+         Abroad     61
+         Abroad     30
+         Abroad     56
+         Abroad    126
+         Abroad    163
+         Abroad   6613
+         Abroad   1394
+         Abroad     21
+         Abroad     96
+         Abroad      9
+         Abroad    638
+         Abroad    180
+         Abroad     74
+         Abroad     10
+         Abroad    341
+ [ reached 'max' / getOption("max.print") -- omitted 1997 rows ]
 
-Query Nr. 16
+Query Nr. 10
 -- How many people who were born in Switzerland  did not possess permanent residency status by 2010?
 SELECT T1.year, T1.population_type,T1.place_of_birth, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True  AND T1.year=2015 AND T1.population_type ='Non permanent resident population' AND T1.place_of_birth ='Switzerland' AND T1.citizenship='Citizenship - total';
  year                   population_type place_of_birth amount
  2015 Non permanent resident population    Switzerland   1663
 
-Query Nr. 17
+Query Nr. 11
 -- How many people who were born in Switzerland did not possess permanent residency status by 2015? List by citizenship
 SELECT T1.year, T1.population_type,T1.place_of_birth, T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True  AND T1.year=2015 AND T1.population_type ='Non permanent resident population' AND T1.place_of_birth ='Switzerland' AND T1.citizenship!='Citizenship - total';
  year                   population_type place_of_birth
@@ -5250,213 +1003,210 @@ SELECT T1.year, T1.population_type,T1.place_of_birth, T1.citizenship, T1.amount 
  2015 Non permanent resident population    Switzerland
  2015 Non permanent resident population    Switzerland
  2015 Non permanent resident population    Switzerland
- 2015 Non permanent resident population    Switzerland
- 2015 Non permanent resident population    Switzerland
                                    citizenship amount
-                                     Sri Lanka     23
                                      Palestine      0
                                       Eswatini      0
                                       Mongolia      3
-                                         Yemen      2
-                                       Armenia      3
                                          Malta      0
-                                    Madagascar      0
-                                         China     13
-                                        Angola     11
-                                      Cambodia      0
-                                          Oman      0
+                                         Yemen      2
                                    Philippines      1
+                                    Madagascar      0
+                                      Cambodia      0
+                                         China     13
+                                          Oman      0
+                                        Angola     11
                                    North Korea      0
                                       Botswana      0
                                       Kiribati      0
-                             Equatorial Guinea      0
                                     Uzbekistan      0
                                        Austria      8
+                             Equatorial Guinea      0
                                         Latvia      0
-                                      Bulgaria      5
+                                          Togo      3
                                  Côte d'Ivoire      2
                                           Laos      0
-                                          Togo      3
-                                         Italy    222
-                          United Arab Emirates      0
                                        Somalia     30
+                                      Bulgaria      5
+                                         Italy    222
                                         Mexico      3
-                                        Canada      9
-                                      Barbados      0
-                                       Myanmar      0
+                      Central African Republic      0
+                          United Arab Emirates      0
                                      Singapore      0
                                        Romania     13
-                                        Guyana      0
-                      Central African Republic      0
                                       Tanzania      0
+                                      Barbados      0
+                                        Canada      9
+                                       Myanmar      0
+                                    Micronesia      0
+                                        Guyana      0
                             Dominican Republic      6
                                       Maldives      0
-                                    Micronesia      0
                          São Tomé and Príncipe      0
                                          Gabon      0
                                         Jordan      0
-                                      Djibouti      1
-                                          Chad      1
                                North Macedonia     25
+                                      Djibouti      1
                                   South Africa      1
                                          Nepal      2
+                                          Chad      1
+                                  Cook Islands      0
                                        Morocco      5
                                        Ireland      1
-                                       Liberia      0
-                                  Cook Islands      0
-                                    Kazakhstan      3
-                                  Turkmenistan      0
-                                      Ethiopia     20
                            Congo (Brazzaville)      3
+                                       Liberia      0
+                                  Turkmenistan      0
                                          Nauru      0
+                                      Ethiopia     20
+                                         Benin      1
                                       Malaysia      1
-                                         Palau      0
                                  Liechtenstein      6
                                      Mauritius      1
+                                    Kazakhstan      3
                                          Libya      1
-                                         Benin      1
                                         Turkey     29
-                                        Malawi      0
                                        Czechia      4
-                                       Ecuador      5
+                                         Palau      0
                                        Georgia      2
+                                        Malawi      0
                                       Zimbabwe      0
+                                       Ecuador      5
                                         Serbia     22
-                                     Nicaragua      0
-                                    Montenegro      3
-                                          Peru      1
-                                        Zambia      0
-                                       Hungary     19
                                        Iceland      0
                                        Belarus      0
                               Marshall Islands      0
-                                       Ukraine      5
+                                          Peru      1
+                                        Zambia      0
+                                       Hungary     19
+                                     Nicaragua      0
+                                    Montenegro      3
+                                        Bhutan      0
                                      Guatemala      1
                                     Cabo Verde      3
                                          India     28
-                                        Bhutan      0
+                                       Ukraine      5
                                          Niger      0
+                                          Mali      0
                                         Gambia      1
                                       Cameroon     10
                                         Greece      4
-                                          Mali      0
                                        Namibia      0
                                           Iraq     16
                            Trinidad and Tobago      0
                               Congo (Kinshasa)     12
                                         Sweden      1
+                                         Spain     87
+                                   Switzerland      0
+                                      Paraguay      1
                                       Slovakia      8
                                 Western Sahara      0
                                         Brazil     18
                                          Syria     50
-                                   Switzerland      0
-                                      Paraguay      1
-                                        France     61
-                                         Spain     87
+                                       Albania      5
                                       Slovenia      2
                                         Guinea      3
-                                   Timor-Leste      0
-                                       Albania      5
                                    South Sudan      0
+                                        France     61
+                                   Timor-Leste      0
                                         Russia     14
-                                         Samoa      0
+                                       Comoros      0
+                                        Israel      2
                                        Eritrea    147
                                Solomon Islands      0
-                                       Comoros      0
+                                         Samoa      0
                                           Fiji      0
-                                        Israel      2
+                                 United States     14
                                   Burkina Faso      1
                                        Tunisia      3
-                                       Bolivia      0
-                                 United States     14
-                                    Tajikistan      0
                                         Kuwait      0
+                                    Tajikistan      0
+                                 No indication     32
+                                       Bolivia      0
                                        Moldova      0
                                     Mauritania      0
-                                 No indication     32
-                                       Lebanon      0
+                                        Panama      0
                        Taiwan (Chinese Taipei)      2
                                       Thailand      3
-                                        Panama      0
-                                       Jamaica      0
-                                        Monaco      0
                                          Japan      4
+                                        Monaco      0
+                                       Lebanon      0
+                                       Jamaica      0
                                        Germany     88
                                  Guinea-Bissau      1
                                          Kenya      2
                                      Stateless      0
+                                    Mozambique      0
  Not attributable according to current borders      0
                                   Saudi Arabia      0
                                       Suriname      0
-                                  Sierra Leone      0
-                                    Mozambique      0
-                                        Kosovo     84
                                        Croatia     11
-                                     Venezuela      1
-                                    Costa Rica      0
+                                        Kosovo     84
                                    New Zealand      0
+                                     Venezuela      1
+                                  Sierra Leone      0
+                                    Costa Rica      0
+                                   Afghanistan     32
                                         Poland     18
+                                United Kingdom     22
+                                    San Marino      0
                                         Brunei      0
                                       Colombia      0
-                                United Kingdom     22
-                                   Afghanistan     32
-                                         Egypt      3
-                                    San Marino      0
+                                          Cuba      0
                                   Vatican City      0
                                        Algeria      8
-                                       Grenada      0
-                                     Indonesia      1
-                                        Tuvalu      0
-                                       Finland      1
-                                   Netherlands      4
-                                       Lesotho      0
                                       Pakistan      4
-                                    Kyrgyzstan      1
                         Bosnia and Herzegovina     10
-                                        Norway      2
-                                    Bangladesh      4
                                          Sudan      2
                                           Iran      5
+                                    Kyrgyzstan      1
+                                         Egypt      3
+                                       Grenada      0
+                                        Tuvalu      0
+                                     Indonesia      1
+                                       Finland      1
+                                       Lesotho      0
+                                   Netherlands      4
+                                    Bangladesh      4
+                                        Norway      2
                            Antigua and Barbuda      0
                                        Uruguay      0
                                         Cyprus      0
-                                          Cuba      0
-                              Papua New Guinea      0
-                                       Andorra      0
-                                       Belgium      4
-                                       Burundi      0
-                                       Estonia      1
-                                        Rwanda      0
-                                       Denmark      2
-                                      Honduras      1
-                                         Chile      4
               Saint Vincent and the Grenadines      0
+                                       Andorra      0
+                              Papua New Guinea      0
+                                        Rwanda      0
+                                       Estonia      1
+                                       Burundi      0
+                                       Belgium      4
+                                      Honduras      1
+                                       Denmark      2
+                                         Chile      4
                                          Qatar      0
-                                         Ghana      3
                                          Tonga      0
+                                         Ghana      3
                                     Seychelles      0
                                       Portugal    281
                                     Azerbaijan      0
                                        Bahamas      0
                                        Senegal      2
-                                       Vanuatu      0
                                    South Korea      1
                                       Dominica      0
+                                       Vanuatu      0
                                        Nigeria      3
                                         Belize      0
                          Saint Kitts and Nevis      0
-                                       Bahrain      1
+                                     Argentina      0
                                          Haiti      0
                                        Vietnam      1
-                                     Argentina      0
-                                     Australia      2
+                                       Bahrain      1
                                     Luxembourg      1
-                                   El Salvador      0
                                      Lithuania      0
-                                        Uganda      0
+                                   El Salvador      0
+                                     Australia      2
                                    Saint Lucia      0
+                                       Armenia      3
+ [ reached 'max' / getOption("max.print") -- omitted 2 rows ]
 
-Query Nr. 18
+Query Nr. 12
 -- Which municipalities had the largest population of people born in Switzerland who did not have permanent residency by 2020? show me top 5.
 SELECT T1.year, T2.name, T1.population_type,T1.place_of_birth, T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.municipal=True  AND T1.year=2020 AND T1.population_type ='Non permanent resident population' AND T1.place_of_birth ='Switzerland' AND T1.citizenship='Citizenship - total' ORDER BY T1.amount DESC LIMIT 5;
  year       name                   population_type place_of_birth
@@ -5472,14 +1222,14 @@ SELECT T1.year, T2.name, T1.population_type,T1.place_of_birth, T1.citizenship, T
  Citizenship - total     28
  Citizenship - total     27
 
-Query Nr. 19
+Query Nr. 13
 -- How many of Swiss residenc were born within the country and had Iranian Citizenship on 2018?
 SELECT T1.year, T1.population_type, T1.place_of_birth, T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.country=True  AND T1.year=2018 AND T1.place_of_birth ='Switzerland' AND T1.citizenship ilike '%iran%';
  year                   population_type place_of_birth citizenship amount
- 2018 Non permanent resident population    Switzerland        Iran      6
  2018     Permanent resident population    Switzerland        Iran    444
+ 2018 Non permanent resident population    Switzerland        Iran      6
 
-Query Nr. 20
+Query Nr. 14
 -- What was the total population count in each canton , considering both non-permanent and permanent residents on the year of 2018?
 SELECT T1.year, T2.name, T1.population_type, T1.place_of_birth, T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.canton=True  AND T1.year=2018 AND T1.place_of_birth ='Place of birth - total' AND T1.citizenship ='Citizenship - total' ORDER BY  T1.amount DESC;
  year                             name                   population_type
@@ -5589,13 +1339,13 @@ SELECT T1.year, T2.name, T1.population_type, T1.place_of_birth, T1.citizenship, 
  Place of birth - total Citizenship - total     121
  Place of birth - total Citizenship - total      89
 
-Query Nr. 21
+Query Nr. 15
 -- How many individuals born abroad in canton zurich hold citizenship from Brazil?
 SELECT T2.name, T1.place_of_birth, T1.citizenship, Sum(T1.amount) from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.canton=True AND T2.name ilike '%Z_rich%'  AND T1.place_of_birth ='Abroad' AND T1.citizenship ilike '%Brazil%' GROUP BY T2.name, T1.place_of_birth, T1.citizenship;
              name place_of_birth citizenship   sum
  Canton of Zurich         Abroad      Brazil 48297
 
-Query Nr. 22
+Query Nr. 16
 -- How many individuals in each canton of Switzerland were born abroad and hold Swiss citizenship?
 SELECT T2.name, T1.place_of_birth, T1.citizenship, Sum(T1.amount) from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.canton=True   AND T1.place_of_birth ='Abroad' AND T1.citizenship ilike '%Switzerland%' GROUP BY T2.name, T1.place_of_birth, T1.citizenship;
                              name place_of_birth citizenship     sum
@@ -5626,1624 +1376,258 @@ SELECT T2.name, T1.place_of_birth, T1.citizenship, Sum(T1.amount) from resident_
                     Canton of Zug         Abroad Switzerland  125701
                  Canton of Zurich         Abroad Switzerland 2054882
 
-Query Nr. 23
+Query Nr. 17
 -- Can you provide the breakdown of the population by different citizenships, different place of the birth and different residentship in the Canton of Obwaldent in 2011?
 SELECT T1.citizenship, T1.population_type, T1.place_of_birth,  T1.amount from resident_population_birthplace_citizenship_type AS T1 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid WHERE T2.canton=True AND T2.name ilike '%Obwalden%' AND T1.year=2011  AND T1.place_of_birth !='Place of birth - total' AND T1.citizenship !='Citizenship - total' ORDER BY citizenship;
-                                   citizenship
-                                   Afghanistan
-                                   Afghanistan
-                                   Afghanistan
-                                   Afghanistan
-                                       Albania
-                                       Albania
-                                       Albania
-                                       Albania
-                                       Algeria
-                                       Algeria
-                                       Algeria
-                                       Algeria
-                                       Andorra
-                                       Andorra
-                                       Andorra
-                                       Andorra
-                                        Angola
-                                        Angola
-                                        Angola
-                                        Angola
-                           Antigua and Barbuda
-                           Antigua and Barbuda
-                           Antigua and Barbuda
-                           Antigua and Barbuda
-                                     Argentina
-                                     Argentina
-                                     Argentina
-                                     Argentina
-                                       Armenia
-                                       Armenia
-                                       Armenia
-                                       Armenia
-                                     Australia
-                                     Australia
-                                     Australia
-                                     Australia
-                                       Austria
-                                       Austria
-                                       Austria
-                                       Austria
-                                    Azerbaijan
-                                    Azerbaijan
-                                    Azerbaijan
-                                    Azerbaijan
-                                       Bahamas
-                                       Bahamas
-                                       Bahamas
-                                       Bahamas
-                                       Bahrain
-                                       Bahrain
-                                       Bahrain
-                                       Bahrain
-                                    Bangladesh
-                                    Bangladesh
-                                    Bangladesh
-                                    Bangladesh
-                                      Barbados
-                                      Barbados
-                                      Barbados
-                                      Barbados
-                                       Belarus
-                                       Belarus
-                                       Belarus
-                                       Belarus
-                                       Belgium
-                                       Belgium
-                                       Belgium
-                                       Belgium
-                                        Belize
-                                        Belize
-                                        Belize
-                                        Belize
-                                         Benin
-                                         Benin
-                                         Benin
-                                         Benin
-                                        Bhutan
-                                        Bhutan
-                                        Bhutan
-                                        Bhutan
-                                       Bolivia
-                                       Bolivia
-                                       Bolivia
-                                       Bolivia
-                        Bosnia and Herzegovina
-                        Bosnia and Herzegovina
-                        Bosnia and Herzegovina
-                        Bosnia and Herzegovina
-                                      Botswana
-                                      Botswana
-                                      Botswana
-                                      Botswana
-                                        Brazil
-                                        Brazil
-                                        Brazil
-                                        Brazil
-                                        Brunei
-                                        Brunei
-                                        Brunei
-                                        Brunei
-                                      Bulgaria
-                                      Bulgaria
-                                      Bulgaria
-                                      Bulgaria
-                                  Burkina Faso
-                                  Burkina Faso
-                                  Burkina Faso
-                                  Burkina Faso
-                                       Burundi
-                                       Burundi
-                                       Burundi
-                                       Burundi
-                                    Cabo Verde
-                                    Cabo Verde
-                                    Cabo Verde
-                                    Cabo Verde
-                                      Cambodia
-                                      Cambodia
-                                      Cambodia
-                                      Cambodia
-                                      Cameroon
-                                      Cameroon
-                                      Cameroon
-                                      Cameroon
-                                        Canada
-                                        Canada
-                                        Canada
-                                        Canada
-                      Central African Republic
-                      Central African Republic
-                      Central African Republic
-                      Central African Republic
-                                          Chad
-                                          Chad
-                                          Chad
-                                          Chad
-                                         Chile
-                                         Chile
-                                         Chile
-                                         Chile
-                                         China
-                                         China
-                                         China
-                                         China
-                                      Colombia
-                                      Colombia
-                                      Colombia
-                                      Colombia
-                                       Comoros
-                                       Comoros
-                                       Comoros
-                                       Comoros
-                           Congo (Brazzaville)
-                           Congo (Brazzaville)
-                           Congo (Brazzaville)
-                           Congo (Brazzaville)
-                              Congo (Kinshasa)
-                              Congo (Kinshasa)
-                              Congo (Kinshasa)
-                              Congo (Kinshasa)
-                                  Cook Islands
-                                  Cook Islands
-                                  Cook Islands
-                                  Cook Islands
-                                    Costa Rica
-                                    Costa Rica
-                                    Costa Rica
-                                    Costa Rica
-                                       Croatia
-                                       Croatia
-                                       Croatia
-                                       Croatia
-                                          Cuba
-                                          Cuba
-                                          Cuba
-                                          Cuba
-                                        Cyprus
-                                        Cyprus
-                                        Cyprus
-                                        Cyprus
-                                       Czechia
-                                       Czechia
-                                       Czechia
-                                       Czechia
-                                 Côte d'Ivoire
-                                 Côte d'Ivoire
-                                 Côte d'Ivoire
-                                 Côte d'Ivoire
-                                       Denmark
-                                       Denmark
-                                       Denmark
-                                       Denmark
-                                      Djibouti
-                                      Djibouti
-                                      Djibouti
-                                      Djibouti
-                                      Dominica
-                                      Dominica
-                                      Dominica
-                                      Dominica
-                            Dominican Republic
-                            Dominican Republic
-                            Dominican Republic
-                            Dominican Republic
-                                       Ecuador
-                                       Ecuador
-                                       Ecuador
-                                       Ecuador
-                                         Egypt
-                                         Egypt
-                                         Egypt
-                                         Egypt
-                                   El Salvador
-                                   El Salvador
-                                   El Salvador
-                                   El Salvador
-                             Equatorial Guinea
-                             Equatorial Guinea
-                             Equatorial Guinea
-                             Equatorial Guinea
-                                       Eritrea
-                                       Eritrea
-                                       Eritrea
-                                       Eritrea
-                                       Estonia
-                                       Estonia
-                                       Estonia
-                                       Estonia
-                                      Eswatini
-                                      Eswatini
-                                      Eswatini
-                                      Eswatini
-                                      Ethiopia
-                                      Ethiopia
-                                      Ethiopia
-                                      Ethiopia
-                                          Fiji
-                                          Fiji
-                                          Fiji
-                                          Fiji
-                                       Finland
-                                       Finland
-                                       Finland
-                                       Finland
-                                        France
-                                        France
-                                        France
-                                        France
-                                         Gabon
-                                         Gabon
-                                         Gabon
-                                         Gabon
-                                        Gambia
-                                        Gambia
-                                        Gambia
-                                        Gambia
-                                       Georgia
-                                       Georgia
-                                       Georgia
-                                       Georgia
-                                       Germany
-                                       Germany
-                                       Germany
-                                       Germany
-                                         Ghana
-                                         Ghana
-                                         Ghana
-                                         Ghana
-                                        Greece
-                                        Greece
-                                        Greece
-                                        Greece
-                                       Grenada
-                                       Grenada
-                                       Grenada
-                                       Grenada
-                                     Guatemala
-                                     Guatemala
-                                     Guatemala
-                                     Guatemala
-                                        Guinea
-                                        Guinea
-                                        Guinea
-                                        Guinea
-                                 Guinea-Bissau
-                                 Guinea-Bissau
-                                 Guinea-Bissau
-                                 Guinea-Bissau
-                                        Guyana
-                                        Guyana
-                                        Guyana
-                                        Guyana
-                                         Haiti
-                                         Haiti
-                                         Haiti
-                                         Haiti
-                                      Honduras
-                                      Honduras
-                                      Honduras
-                                      Honduras
-                                       Hungary
-                                       Hungary
-                                       Hungary
-                                       Hungary
-                                       Iceland
-                                       Iceland
-                                       Iceland
-                                       Iceland
-                                         India
-                                         India
-                                         India
-                                         India
-                                     Indonesia
-                                     Indonesia
-                                     Indonesia
-                                     Indonesia
-                                          Iran
-                                          Iran
-                                          Iran
-                                          Iran
-                                          Iraq
-                                          Iraq
-                                          Iraq
-                                          Iraq
-                                       Ireland
-                                       Ireland
-                                       Ireland
-                                       Ireland
-                                        Israel
-                                        Israel
-                                        Israel
-                                        Israel
-                                         Italy
-                                         Italy
-                                         Italy
-                                         Italy
-                                       Jamaica
-                                       Jamaica
-                                       Jamaica
-                                       Jamaica
-                                         Japan
-                                         Japan
-                                         Japan
-                                         Japan
-                                        Jordan
-                                        Jordan
-                                        Jordan
-                                        Jordan
-                                    Kazakhstan
-                                    Kazakhstan
-                                    Kazakhstan
-                                    Kazakhstan
-                                         Kenya
-                                         Kenya
-                                         Kenya
-                                         Kenya
-                                      Kiribati
-                                      Kiribati
-                                      Kiribati
-                                      Kiribati
-                                        Kosovo
-                                        Kosovo
-                                        Kosovo
-                                        Kosovo
-                                        Kuwait
-                                        Kuwait
-                                        Kuwait
-                                        Kuwait
-                                    Kyrgyzstan
-                                    Kyrgyzstan
-                                    Kyrgyzstan
-                                    Kyrgyzstan
-                                          Laos
-                                          Laos
-                                          Laos
-                                          Laos
-                                        Latvia
-                                        Latvia
-                                        Latvia
-                                        Latvia
-                                       Lebanon
-                                       Lebanon
-                                       Lebanon
-                                       Lebanon
-                                       Lesotho
-                                       Lesotho
-                                       Lesotho
-                                       Lesotho
-                                       Liberia
-                                       Liberia
-                                       Liberia
-                                       Liberia
-                                         Libya
-                                         Libya
-                                         Libya
-                                         Libya
-                                 Liechtenstein
-                                 Liechtenstein
-                                 Liechtenstein
-                                 Liechtenstein
-                                     Lithuania
-                                     Lithuania
-                                     Lithuania
-                                     Lithuania
-                                    Luxembourg
-                                    Luxembourg
-                                    Luxembourg
-                                    Luxembourg
-                                    Madagascar
-                                    Madagascar
-                                    Madagascar
-                                    Madagascar
-                                        Malawi
-                                        Malawi
-                                        Malawi
-                                        Malawi
-                                      Malaysia
-                                      Malaysia
-                                      Malaysia
-                                      Malaysia
-                                      Maldives
-                                      Maldives
-                                      Maldives
-                                      Maldives
-                                          Mali
-                                          Mali
-                                          Mali
-                                          Mali
-                                         Malta
-                                         Malta
-                                         Malta
-                                         Malta
-                              Marshall Islands
-                              Marshall Islands
-                              Marshall Islands
-                              Marshall Islands
-                                    Mauritania
-                                    Mauritania
-                                    Mauritania
-                                    Mauritania
-                                     Mauritius
-                                     Mauritius
-                                     Mauritius
-                                     Mauritius
-                                        Mexico
-                                        Mexico
-                                        Mexico
-                                        Mexico
-                                    Micronesia
-                                    Micronesia
-                                    Micronesia
-                                    Micronesia
-                                       Moldova
-                                       Moldova
-                                       Moldova
-                                       Moldova
-                                        Monaco
-                                        Monaco
-                                        Monaco
-                                        Monaco
-                                      Mongolia
-                                      Mongolia
-                                      Mongolia
-                                      Mongolia
-                                    Montenegro
-                                    Montenegro
-                                    Montenegro
-                                    Montenegro
-                                       Morocco
-                                       Morocco
-                                       Morocco
-                                       Morocco
-                                    Mozambique
-                                    Mozambique
-                                    Mozambique
-                                    Mozambique
-                                       Myanmar
-                                       Myanmar
-                                       Myanmar
-                                       Myanmar
-                                       Namibia
-                                       Namibia
-                                       Namibia
-                                       Namibia
-                                         Nauru
-                                         Nauru
-                                         Nauru
-                                         Nauru
-                                         Nepal
-                                         Nepal
-                                         Nepal
-                                         Nepal
-                                   Netherlands
-                                   Netherlands
-                                   Netherlands
-                                   Netherlands
-                                   New Zealand
-                                   New Zealand
-                                   New Zealand
-                                   New Zealand
-                                     Nicaragua
-                                     Nicaragua
-                                     Nicaragua
-                                     Nicaragua
-                                         Niger
-                                         Niger
-                                         Niger
-                                         Niger
-                                       Nigeria
-                                       Nigeria
-                                       Nigeria
-                                       Nigeria
-                                 No indication
-                                 No indication
-                                 No indication
-                                 No indication
-                                   North Korea
-                                   North Korea
-                                   North Korea
-                                   North Korea
-                               North Macedonia
-                               North Macedonia
-                               North Macedonia
-                               North Macedonia
-                                        Norway
-                                        Norway
-                                        Norway
-                                        Norway
- Not attributable according to current borders
- Not attributable according to current borders
- Not attributable according to current borders
- Not attributable according to current borders
-                                          Oman
-                                          Oman
-                                          Oman
-                                          Oman
-                                      Pakistan
-                                      Pakistan
-                                      Pakistan
-                                      Pakistan
-                                         Palau
-                                         Palau
-                                         Palau
-                                         Palau
-                                     Palestine
-                                     Palestine
-                                     Palestine
-                                     Palestine
-                                        Panama
-                                        Panama
-                                        Panama
-                                        Panama
-                              Papua New Guinea
-                              Papua New Guinea
-                              Papua New Guinea
-                              Papua New Guinea
-                                      Paraguay
-                                      Paraguay
-                                      Paraguay
-                                      Paraguay
-                                          Peru
-                                          Peru
-                                          Peru
-                                          Peru
-                                   Philippines
-                                   Philippines
-                                   Philippines
-                                   Philippines
-                                        Poland
-                                        Poland
-                                        Poland
-                                        Poland
-                                      Portugal
-                                      Portugal
-                                      Portugal
-                                      Portugal
-                                         Qatar
-                                         Qatar
-                                         Qatar
-                                         Qatar
-                                       Romania
-                                       Romania
-                                       Romania
-                                       Romania
-                                        Russia
-                                        Russia
-                                        Russia
-                                        Russia
-                                        Rwanda
-                                        Rwanda
-                                        Rwanda
-                                        Rwanda
-                         Saint Kitts and Nevis
-                         Saint Kitts and Nevis
-                         Saint Kitts and Nevis
-                         Saint Kitts and Nevis
-                                   Saint Lucia
-                                   Saint Lucia
-                                   Saint Lucia
-                                   Saint Lucia
-              Saint Vincent and the Grenadines
-              Saint Vincent and the Grenadines
-              Saint Vincent and the Grenadines
-              Saint Vincent and the Grenadines
-                                         Samoa
-                                         Samoa
-                                         Samoa
-                                         Samoa
-                                    San Marino
-                                    San Marino
-                                    San Marino
-                                    San Marino
-                                  Saudi Arabia
-                                  Saudi Arabia
-                                  Saudi Arabia
-                                  Saudi Arabia
-                                       Senegal
-                                       Senegal
-                                       Senegal
-                                       Senegal
-                                        Serbia
-                                        Serbia
-                                        Serbia
-                                        Serbia
-                                    Seychelles
-                                    Seychelles
-                                    Seychelles
-                                    Seychelles
-                                  Sierra Leone
-                                  Sierra Leone
-                                  Sierra Leone
-                                  Sierra Leone
-                                     Singapore
-                                     Singapore
-                                     Singapore
-                                     Singapore
-                                      Slovakia
-                                      Slovakia
-                                      Slovakia
-                                      Slovakia
-                                      Slovenia
-                                      Slovenia
-                                      Slovenia
-                                      Slovenia
-                               Solomon Islands
-                               Solomon Islands
-                               Solomon Islands
-                               Solomon Islands
-                                       Somalia
-                                       Somalia
-                                       Somalia
-                                       Somalia
-                                  South Africa
-                                  South Africa
-                                  South Africa
-                                  South Africa
-                                   South Korea
-                                   South Korea
-                                   South Korea
-                                   South Korea
-                                   South Sudan
-                                   South Sudan
-                                   South Sudan
-                                   South Sudan
-                                         Spain
-                                         Spain
-                                         Spain
-                                         Spain
-                                     Sri Lanka
-                                     Sri Lanka
-                                     Sri Lanka
-                                     Sri Lanka
-                                     Stateless
-                                     Stateless
-                                     Stateless
-                                     Stateless
-                                         Sudan
-                                         Sudan
-                                         Sudan
-                                         Sudan
-                                      Suriname
-                                      Suriname
-                                      Suriname
-                                      Suriname
-                                        Sweden
-                                        Sweden
-                                        Sweden
-                                        Sweden
-                                   Switzerland
-                                   Switzerland
-                                   Switzerland
-                                   Switzerland
-                                         Syria
-                                         Syria
-                                         Syria
-                                         Syria
-                         São Tomé and Príncipe
-                         São Tomé and Príncipe
-                         São Tomé and Príncipe
-                         São Tomé and Príncipe
-                       Taiwan (Chinese Taipei)
-                       Taiwan (Chinese Taipei)
-                       Taiwan (Chinese Taipei)
-                       Taiwan (Chinese Taipei)
-                                    Tajikistan
-                                    Tajikistan
-                                    Tajikistan
-                                    Tajikistan
-                                      Tanzania
-                                      Tanzania
-                                      Tanzania
-                                      Tanzania
-                                      Thailand
-                                      Thailand
-                                      Thailand
-                                      Thailand
-                                   Timor-Leste
-                                   Timor-Leste
-                                   Timor-Leste
-                                   Timor-Leste
-                                          Togo
-                                          Togo
-                                          Togo
-                                          Togo
-                                         Tonga
-                                         Tonga
-                                         Tonga
-                                         Tonga
-                           Trinidad and Tobago
-                           Trinidad and Tobago
-                           Trinidad and Tobago
-                           Trinidad and Tobago
-                                       Tunisia
-                                       Tunisia
-                                       Tunisia
-                                       Tunisia
-                                        Turkey
-                                        Turkey
-                                        Turkey
-                                        Turkey
-                                  Turkmenistan
-                                  Turkmenistan
-                                  Turkmenistan
-                                  Turkmenistan
-                                        Tuvalu
-                                        Tuvalu
-                                        Tuvalu
-                                        Tuvalu
-                                        Uganda
-                                        Uganda
-                                        Uganda
-                                        Uganda
-                                       Ukraine
-                                       Ukraine
-                                       Ukraine
-                                       Ukraine
-                          United Arab Emirates
-                          United Arab Emirates
-                          United Arab Emirates
-                          United Arab Emirates
-                                United Kingdom
-                                United Kingdom
-                                United Kingdom
-                                United Kingdom
-                                 United States
-                                 United States
-                                 United States
-                                 United States
-                                       Uruguay
-                                       Uruguay
-                                       Uruguay
-                                       Uruguay
-                                    Uzbekistan
-                                    Uzbekistan
-                                    Uzbekistan
-                                    Uzbekistan
-                                       Vanuatu
-                                       Vanuatu
-                                       Vanuatu
-                                       Vanuatu
-                                  Vatican City
-                                  Vatican City
-                                  Vatican City
-                                  Vatican City
-                                     Venezuela
-                                     Venezuela
-                                     Venezuela
-                                     Venezuela
-                                       Vietnam
-                                       Vietnam
-                                       Vietnam
-                                       Vietnam
-                                Western Sahara
-                                Western Sahara
-                                Western Sahara
-                                Western Sahara
-                                         Yemen
-                                         Yemen
-                                         Yemen
-                                         Yemen
-                                        Zambia
-                                        Zambia
-                                        Zambia
-                                        Zambia
-                                      Zimbabwe
-                                      Zimbabwe
-                                      Zimbabwe
-                                      Zimbabwe
-                   population_type place_of_birth amount
-     Permanent resident population         Abroad      3
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      2
- Non permanent resident population         Abroad      9
-     Permanent resident population    Switzerland      1
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad      2
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      8
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      3
-     Permanent resident population         Abroad    122
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland     10
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     12
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      2
-     Permanent resident population    Switzerland      4
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
-     Permanent resident population         Abroad     86
-     Permanent resident population    Switzerland     33
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     23
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      2
-     Permanent resident population         Abroad      3
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      4
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      9
-     Permanent resident population    Switzerland      2
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      3
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      7
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     15
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      2
-     Permanent resident population    Switzerland      1
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      2
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad    106
- Non permanent resident population         Abroad      1
-     Permanent resident population    Switzerland     61
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      3
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      4
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     12
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad     19
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      2
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      4
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      1
-     Permanent resident population         Abroad      6
-     Permanent resident population         Abroad      2
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      4
- Non permanent resident population         Abroad     11
-     Permanent resident population         Abroad     38
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      2
-     Permanent resident population    Switzerland      3
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      4
-     Permanent resident population         Abroad      9
-     Permanent resident population    Switzerland      2
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      2
- Non permanent resident population         Abroad      2
-     Permanent resident population         Abroad     33
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      2
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      1
-     Permanent resident population         Abroad      2
-     Permanent resident population    Switzerland     96
-     Permanent resident population         Abroad   1273
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad    162
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      4
- Non permanent resident population         Abroad      2
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     13
- Non permanent resident population         Abroad     14
-     Permanent resident population    Switzerland      1
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      3
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     12
- Non permanent resident population         Abroad     12
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      1
- Non permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     11
-     Permanent resident population         Abroad     30
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      9
-     Permanent resident population         Abroad      3
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland    137
- Non permanent resident population         Abroad     33
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad    210
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      4
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      2
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad    153
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland     44
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      1
-     Permanent resident population         Abroad      3
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      2
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad      2
- Non permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      1
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad     27
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland     11
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      1
-     Permanent resident population         Abroad      6
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     94
- Non permanent resident population         Abroad      1
-     Permanent resident population    Switzerland     10
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
- Non permanent resident population         Abroad      8
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      2
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad    154
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland     59
- Non permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      3
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      2
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      6
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      2
-     Permanent resident population         Abroad     22
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      9
- Non permanent resident population         Abroad     51
- Non permanent resident population    Switzerland      1
-     Permanent resident population    Switzerland    167
-     Permanent resident population         Abroad    680
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     10
- Non permanent resident population         Abroad      4
-     Permanent resident population    Switzerland      8
-     Permanent resident population         Abroad     48
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad    231
- Non permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland     72
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     17
- Non permanent resident population         Abroad     13
-     Permanent resident population    Switzerland      1
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      9
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     13
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      2
- Non permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      2
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland     20
-     Permanent resident population         Abroad     48
- Non permanent resident population         Abroad      7
-     Permanent resident population    Switzerland     32
- Non permanent resident population    Switzerland      1
- Non permanent resident population         Abroad      5
-     Permanent resident population         Abroad    100
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad     23
-     Permanent resident population         Abroad     48
-     Permanent resident population    Switzerland      6
-     Permanent resident population    Switzerland  29423
-     Permanent resident population         Abroad   1546
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      2
-     Permanent resident population    Switzerland      1
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      3
-     Permanent resident population    Switzerland      1
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
-     Permanent resident population    Switzerland      1
-     Permanent resident population         Abroad     32
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      2
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad     10
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland     31
- Non permanent resident population         Abroad      4
-     Permanent resident population         Abroad     94
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      4
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad     30
-     Permanent resident population    Switzerland      1
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad     72
-     Permanent resident population    Switzerland      8
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      5
-     Permanent resident population    Switzerland      5
- Non permanent resident population         Abroad      3
-     Permanent resident population         Abroad     25
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      6
- Non permanent resident population         Abroad      2
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      3
- Non permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      2
- Non permanent resident population         Abroad      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
-     Permanent resident population    Switzerland      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
-     Permanent resident population         Abroad      0
- Non permanent resident population    Switzerland      0
- Non permanent resident population         Abroad      0
-     Permanent resident population    Switzerland      0
+              citizenship                   population_type place_of_birth amount
+              Afghanistan     Permanent resident population         Abroad      3
+              Afghanistan Non permanent resident population         Abroad      9
+              Afghanistan Non permanent resident population    Switzerland      0
+              Afghanistan     Permanent resident population    Switzerland      2
+                  Albania Non permanent resident population    Switzerland      0
+                  Albania     Permanent resident population         Abroad      1
+                  Albania     Permanent resident population    Switzerland      1
+                  Albania Non permanent resident population         Abroad      0
+                  Algeria Non permanent resident population         Abroad      0
+                  Algeria     Permanent resident population    Switzerland      0
+                  Algeria     Permanent resident population         Abroad      0
+                  Algeria Non permanent resident population    Switzerland      0
+                  Andorra Non permanent resident population    Switzerland      0
+                  Andorra     Permanent resident population    Switzerland      0
+                  Andorra     Permanent resident population         Abroad      0
+                  Andorra Non permanent resident population         Abroad      0
+                   Angola Non permanent resident population    Switzerland      0
+                   Angola Non permanent resident population         Abroad      0
+                   Angola     Permanent resident population    Switzerland      0
+                   Angola     Permanent resident population         Abroad      2
+      Antigua and Barbuda     Permanent resident population         Abroad      0
+      Antigua and Barbuda     Permanent resident population    Switzerland      0
+      Antigua and Barbuda Non permanent resident population         Abroad      0
+      Antigua and Barbuda Non permanent resident population    Switzerland      0
+                Argentina Non permanent resident population    Switzerland      0
+                Argentina Non permanent resident population         Abroad      0
+                Argentina     Permanent resident population    Switzerland      0
+                Argentina     Permanent resident population         Abroad      0
+                  Armenia Non permanent resident population    Switzerland      0
+                  Armenia Non permanent resident population         Abroad      0
+                  Armenia     Permanent resident population         Abroad      0
+                  Armenia     Permanent resident population    Switzerland      0
+                Australia     Permanent resident population         Abroad      8
+                Australia Non permanent resident population         Abroad      0
+                Australia     Permanent resident population    Switzerland      0
+                Australia Non permanent resident population    Switzerland      0
+                  Austria     Permanent resident population         Abroad    122
+                  Austria     Permanent resident population    Switzerland     10
+                  Austria Non permanent resident population         Abroad      3
+                  Austria Non permanent resident population    Switzerland      0
+               Azerbaijan     Permanent resident population         Abroad      1
+               Azerbaijan Non permanent resident population         Abroad      0
+               Azerbaijan     Permanent resident population    Switzerland      0
+               Azerbaijan Non permanent resident population    Switzerland      0
+                  Bahamas Non permanent resident population         Abroad      0
+                  Bahamas     Permanent resident population    Switzerland      0
+                  Bahamas Non permanent resident population    Switzerland      0
+                  Bahamas     Permanent resident population         Abroad      0
+                  Bahrain Non permanent resident population         Abroad      0
+                  Bahrain     Permanent resident population         Abroad      0
+                  Bahrain Non permanent resident population    Switzerland      0
+                  Bahrain     Permanent resident population    Switzerland      0
+               Bangladesh     Permanent resident population         Abroad      0
+               Bangladesh Non permanent resident population    Switzerland      0
+               Bangladesh Non permanent resident population         Abroad      0
+               Bangladesh     Permanent resident population    Switzerland      0
+                 Barbados     Permanent resident population    Switzerland      0
+                 Barbados Non permanent resident population    Switzerland      0
+                 Barbados     Permanent resident population         Abroad      0
+                 Barbados Non permanent resident population         Abroad      0
+                  Belarus     Permanent resident population    Switzerland      0
+                  Belarus Non permanent resident population         Abroad      0
+                  Belarus Non permanent resident population    Switzerland      0
+                  Belarus     Permanent resident population         Abroad      0
+                  Belgium     Permanent resident population    Switzerland      4
+                  Belgium Non permanent resident population         Abroad      2
+                  Belgium Non permanent resident population    Switzerland      0
+                  Belgium     Permanent resident population         Abroad     12
+                   Belize     Permanent resident population    Switzerland      0
+                   Belize Non permanent resident population    Switzerland      0
+                   Belize     Permanent resident population         Abroad      0
+                   Belize Non permanent resident population         Abroad      0
+                    Benin Non permanent resident population         Abroad      0
+                    Benin     Permanent resident population    Switzerland      0
+                    Benin Non permanent resident population    Switzerland      0
+                    Benin     Permanent resident population         Abroad      0
+                   Bhutan Non permanent resident population         Abroad      0
+                   Bhutan     Permanent resident population         Abroad      0
+                   Bhutan     Permanent resident population    Switzerland      0
+                   Bhutan Non permanent resident population    Switzerland      0
+                  Bolivia     Permanent resident population         Abroad      1
+                  Bolivia Non permanent resident population    Switzerland      0
+                  Bolivia Non permanent resident population         Abroad      0
+                  Bolivia     Permanent resident population    Switzerland      0
+   Bosnia and Herzegovina     Permanent resident population         Abroad     86
+   Bosnia and Herzegovina     Permanent resident population    Switzerland     33
+   Bosnia and Herzegovina Non permanent resident population    Switzerland      0
+   Bosnia and Herzegovina Non permanent resident population         Abroad      0
+                 Botswana Non permanent resident population         Abroad      0
+                 Botswana Non permanent resident population    Switzerland      0
+                 Botswana     Permanent resident population         Abroad      0
+                 Botswana     Permanent resident population    Switzerland      0
+                   Brazil Non permanent resident population    Switzerland      0
+                   Brazil     Permanent resident population    Switzerland      0
+                   Brazil Non permanent resident population         Abroad      0
+                   Brazil     Permanent resident population         Abroad     23
+                   Brunei     Permanent resident population    Switzerland      0
+                   Brunei Non permanent resident population         Abroad      0
+                   Brunei     Permanent resident population         Abroad      0
+                   Brunei Non permanent resident population    Switzerland      0
+                 Bulgaria Non permanent resident population         Abroad      2
+                 Bulgaria     Permanent resident population         Abroad      3
+                 Bulgaria Non permanent resident population    Switzerland      0
+                 Bulgaria     Permanent resident population    Switzerland      0
+             Burkina Faso     Permanent resident population    Switzerland      0
+             Burkina Faso Non permanent resident population    Switzerland      0
+             Burkina Faso     Permanent resident population         Abroad      0
+             Burkina Faso Non permanent resident population         Abroad      0
+                  Burundi Non permanent resident population    Switzerland      0
+                  Burundi     Permanent resident population    Switzerland      0
+                  Burundi Non permanent resident population         Abroad      0
+                  Burundi     Permanent resident population         Abroad      0
+               Cabo Verde     Permanent resident population    Switzerland      0
+               Cabo Verde Non permanent resident population         Abroad      0
+               Cabo Verde     Permanent resident population         Abroad      0
+               Cabo Verde Non permanent resident population    Switzerland      0
+                 Cambodia     Permanent resident population    Switzerland      0
+                 Cambodia Non permanent resident population         Abroad      0
+                 Cambodia     Permanent resident population         Abroad      1
+                 Cambodia Non permanent resident population    Switzerland      0
+                 Cameroon     Permanent resident population    Switzerland      0
+                 Cameroon     Permanent resident population         Abroad      4
+                 Cameroon Non permanent resident population    Switzerland      0
+                 Cameroon Non permanent resident population         Abroad      0
+                   Canada Non permanent resident population         Abroad      0
+                   Canada     Permanent resident population    Switzerland      2
+                   Canada     Permanent resident population         Abroad      9
+                   Canada Non permanent resident population    Switzerland      0
+ Central African Republic Non permanent resident population         Abroad      0
+ Central African Republic     Permanent resident population    Switzerland      0
+ Central African Republic Non permanent resident population    Switzerland      0
+ Central African Republic     Permanent resident population         Abroad      0
+                     Chad     Permanent resident population    Switzerland      0
+                     Chad Non permanent resident population         Abroad      0
+                     Chad     Permanent resident population         Abroad      0
+                     Chad Non permanent resident population    Switzerland      0
+                    Chile     Permanent resident population    Switzerland      0
+                    Chile Non permanent resident population    Switzerland      0
+                    Chile     Permanent resident population         Abroad      3
+                    Chile Non permanent resident population         Abroad      0
+                    China     Permanent resident population    Switzerland      0
+                    China Non permanent resident population    Switzerland      0
+                    China Non permanent resident population         Abroad      7
+                    China     Permanent resident population         Abroad     15
+                 Colombia Non permanent resident population    Switzerland      0
+                 Colombia     Permanent resident population    Switzerland      1
+                 Colombia     Permanent resident population         Abroad      2
+                 Colombia Non permanent resident population         Abroad      0
+                  Comoros     Permanent resident population    Switzerland      0
+                  Comoros Non permanent resident population    Switzerland      0
+                  Comoros Non permanent resident population         Abroad      0
+                  Comoros     Permanent resident population         Abroad      0
+      Congo (Brazzaville)     Permanent resident population    Switzerland      0
+      Congo (Brazzaville) Non permanent resident population    Switzerland      0
+      Congo (Brazzaville) Non permanent resident population         Abroad      0
+      Congo (Brazzaville)     Permanent resident population         Abroad      0
+         Congo (Kinshasa)     Permanent resident population    Switzerland      0
+         Congo (Kinshasa)     Permanent resident population         Abroad      0
+         Congo (Kinshasa) Non permanent resident population    Switzerland      0
+         Congo (Kinshasa) Non permanent resident population         Abroad      0
+             Cook Islands     Permanent resident population    Switzerland      0
+             Cook Islands Non permanent resident population         Abroad      0
+             Cook Islands Non permanent resident population    Switzerland      0
+             Cook Islands     Permanent resident population         Abroad      0
+               Costa Rica Non permanent resident population         Abroad      0
+               Costa Rica Non permanent resident population    Switzerland      0
+               Costa Rica     Permanent resident population    Switzerland      0
+               Costa Rica     Permanent resident population         Abroad      2
+                  Croatia Non permanent resident population         Abroad      1
+                  Croatia Non permanent resident population    Switzerland      0
+                  Croatia     Permanent resident population         Abroad    106
+                  Croatia     Permanent resident population    Switzerland     61
+                     Cuba Non permanent resident population    Switzerland      0
+                     Cuba     Permanent resident population    Switzerland      0
+                     Cuba Non permanent resident population         Abroad      0
+                     Cuba     Permanent resident population         Abroad      3
+                   Cyprus Non permanent resident population    Switzerland      0
+                   Cyprus     Permanent resident population         Abroad      0
+                   Cyprus     Permanent resident population    Switzerland      0
+                   Cyprus Non permanent resident population         Abroad      0
+                  Czechia     Permanent resident population         Abroad     12
+                  Czechia Non permanent resident population    Switzerland      0
+                  Czechia Non permanent resident population         Abroad      4
+                  Czechia     Permanent resident population    Switzerland      0
+            Côte d'Ivoire     Permanent resident population         Abroad      0
+            Côte d'Ivoire Non permanent resident population         Abroad      0
+            Côte d'Ivoire Non permanent resident population    Switzerland      0
+            Côte d'Ivoire     Permanent resident population    Switzerland      0
+                  Denmark Non permanent resident population         Abroad      2
+                  Denmark     Permanent resident population    Switzerland      0
+                  Denmark     Permanent resident population         Abroad     19
+                  Denmark Non permanent resident population    Switzerland      0
+                 Djibouti     Permanent resident population    Switzerland      0
+                 Djibouti     Permanent resident population         Abroad      0
+                 Djibouti Non permanent resident population         Abroad      0
+                 Djibouti Non permanent resident population    Switzerland      0
+                 Dominica     Permanent resident population    Switzerland      0
+                 Dominica     Permanent resident population         Abroad      0
+                 Dominica Non permanent resident population    Switzerland      0
+                 Dominica Non permanent resident population         Abroad      0
+       Dominican Republic Non permanent resident population    Switzerland      0
+       Dominican Republic     Permanent resident population         Abroad      6
+       Dominican Republic Non permanent resident population         Abroad      4
+       Dominican Republic     Permanent resident population    Switzerland      1
+                  Ecuador Non permanent resident population    Switzerland      0
+                  Ecuador     Permanent resident population    Switzerland      0
+                  Ecuador Non permanent resident population         Abroad      0
+                  Ecuador     Permanent resident population         Abroad      2
+                    Egypt Non permanent resident population         Abroad      0
+                    Egypt     Permanent resident population         Abroad      0
+                    Egypt     Permanent resident population    Switzerland      0
+                    Egypt Non permanent resident population    Switzerland      0
+              El Salvador Non permanent resident population         Abroad      0
+              El Salvador     Permanent resident population         Abroad      0
+              El Salvador Non permanent resident population    Switzerland      0
+              El Salvador     Permanent resident population    Switzerland      0
+        Equatorial Guinea Non permanent resident population         Abroad      0
+        Equatorial Guinea     Permanent resident population         Abroad      0
+        Equatorial Guinea Non permanent resident population    Switzerland      0
+        Equatorial Guinea     Permanent resident population    Switzerland      0
+                  Eritrea     Permanent resident population    Switzerland      4
+                  Eritrea Non permanent resident population         Abroad     11
+                  Eritrea Non permanent resident population    Switzerland      0
+                  Eritrea     Permanent resident population         Abroad     38
+                  Estonia Non permanent resident population         Abroad      0
+                  Estonia Non permanent resident population    Switzerland      0
+                  Estonia     Permanent resident population    Switzerland      0
+                  Estonia     Permanent resident population         Abroad      1
+                 Eswatini Non permanent resident population    Switzerland      0
+                 Eswatini     Permanent resident population         Abroad      0
+                 Eswatini     Permanent resident population    Switzerland      0
+                 Eswatini Non permanent resident population         Abroad      0
+                 Ethiopia Non permanent resident population         Abroad      0
+                 Ethiopia     Permanent resident population         Abroad      2
+                 Ethiopia Non permanent resident population    Switzerland      0
+                 Ethiopia     Permanent resident population    Switzerland      3
+                     Fiji Non permanent resident population    Switzerland      0
+                     Fiji     Permanent resident population    Switzerland      0
+                     Fiji Non permanent resident population         Abroad      0
+                     Fiji     Permanent resident population         Abroad      0
+                  Finland     Permanent resident population    Switzerland      2
+                  Finland Non permanent resident population         Abroad      4
+                  Finland Non permanent resident population    Switzerland      0
+                  Finland     Permanent resident population         Abroad      9
+                   France Non permanent resident population         Abroad      2
+                   France     Permanent resident population         Abroad     33
+                   France     Permanent resident population    Switzerland      2
+                   France Non permanent resident population    Switzerland      0
+                    Gabon     Permanent resident population         Abroad      0
+                    Gabon Non permanent resident population    Switzerland      0
+ [ reached 'max' / getOption("max.print") -- omitted 558 rows ]

--- a/pipelines/B6/queries.sql
+++ b/pipelines/B6/queries.sql
@@ -1,40 +1,4 @@
--- How many vehicles do we have in canton zurich in 2020?
-SELECT S.name, sum(T.amount) as amount from stock_vehicles as T
-JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
-WHERE S.name ilike '%Zurich%'  and T.year=2020 and S.canton=True
-GROUP BY S.name;
-
--- How many vehicles do we have in the city of zurich in 2021?
-SELECT S.name, S.spatialunit_ontology, sum(T.amount) as amount from stock_vehicles as T
-JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
-WHERE S.name ilike '%Z_rich%'  and T.year=2021 and S.municipal=True and T.fuel_type != 'total'
-GROUP BY S.name, S.spatialunit_ontology;
-
--- How many vehicles do we have in zurich in 2020?
-SELECT S.name, S.spatialunit_ontology, sum(T.amount) as amount from stock_vehicles as T
-JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
-WHERE S.name ilike '%Z_rich%'  and T.year=2020 and (S.canton=True or S.municipal=True or S.district=True)
-GROUP BY S.name, S.spatialunit_ontology;
-
--- How many electric cars do we have in the city of basel?
-SELECT S.name, S.spatialunit_ontology,T.fuel_type,T.year, sum(T.amount) as amount from stock_vehicles as T
-JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
-WHERE S.name ilike '%basel%'  and S.municipal=True and T.fuel_type ='Electric'
-GROUP BY S.spatialunit_ontology, S.name,T.fuel_type, T.year;
-
--- How many hybrid cars do we have in the city of basel?
-SELECT S.name, S.spatialunit_ontology,T.fuel_type,T.year, sum(T.amount) as amount from stock_vehicles as T
-JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
-WHERE S.name ilike '%basel%'  and S.municipal=True and T.fuel_type ilike '%hybrid%'
-GROUP BY S.spatialunit_ontology, S.name,T.fuel_type, T.year;
-
--- give me the total number of passenger cars that are using diesel in each canton?
-SELECT S.name, S.spatialunit_ontology,T.fuel_type, sum(T.amount) as amount from stock_vehicles as T
-JOIN spatial_unit as S on T.spatialunit_uid = S.spatialunit_uid
-WHERE  S.canton=True and T.fuel_type ilike '%diesel%' and T.vehicle_type ='passenger_cars'
-GROUP BY S.spatialunit_ontology, S.name,T.fuel_type;
-
--- How many of the permanent population of Switzerlan have been born Aborad on the year of 2020?
+-- How many of the permanent population of Switzerland have been born Aborad on the year of 2020?
 SELECT T1.year, T1.population_type,T1.place_of_birth,T1.citizenship, T1.amount from resident_population_birthplace_citizenship_type AS T1
 JOIN spatial_unit AS T2 ON T1.spatialunit_uid = T2.spatialunit_uid
 WHERE T2.country=True AND T1.year=2020 AND T1.population_type ='Permanent resident population' AND T1.place_of_birth ='Abroad' AND T1.citizenship='Citizenship - total';


### PR DESCRIPTION
This PR move queries that have been by mistake added to pipeline B6 to the pipeline B1, as these queries query the table `stock_vehicles` that was generated by pipeline B1